### PR TITLE
chore: update package-lock.json for v1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "vite-plugin-react-server": "1.2.2"
+        "vite-plugin-react-server": "1.2.3"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
@@ -9318,9 +9318,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.2.tgz",
-      "integrity": "sha512-wl8CIgRIl0oDo4RtHmL8UES78wBKkgWOoMC3Z4Ec206bbKHpURiQtxpt6XTlprmvVTlQtxHnYhQjlQY/x6lWzA==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.3.tgz",
+      "integrity": "sha512-/r5DxexV2Mv9WvAaefQRNhDpxOKtuIuz7vUFGR6os6G0V+kvNPlMoEQIbWlTevkohGJi+5aYjeht/JATzlKEEw==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
Updates lockfile so npm ci works with the 1.2.3 bump.