### PR TITLE
chore: bump vite-plugin-react-server to 1.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.1",
       "hasInstallScript": true,
       "dependencies": {
-        "vite-plugin-react-server": "1.2.3"
+        "vite-plugin-react-server": "1.2.4"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
@@ -9318,9 +9318,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.3.tgz",
-      "integrity": "sha512-/r5DxexV2Mv9WvAaefQRNhDpxOKtuIuz7vUFGR6os6G0V+kvNPlMoEQIbWlTevkohGJi+5aYjeht/JATzlKEEw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.2.4.tgz",
+      "integrity": "sha512-mMRbe8DnLcTAgLbFyTYBKjM67erTVJl0DFQhb6xXpGzwJ+i6Swk78QbeI/voEXJYMQMpVhkkRHG5KhaGlQmB8A==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
     "react-dom": "$react-dom"
   },
   "dependencies": {
-    "vite-plugin-react-server": "1.2.3"
+    "vite-plugin-react-server": "1.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -131,6 +131,6 @@
     "react-dom": "$react-dom"
   },
   "dependencies": {
-    "vite-plugin-react-server": "1.2.4"
+    "vite-plugin-react-server": "1.2.5"
   }
 }


### PR DESCRIPTION
Bumps vite-plugin-react-server from 1.2.3 to 1.2.4.

**Changes in 1.2.4:**
- fix: handle Vite preload helper injection before directives