### PR TITLE
chore: bump vite-plugin-react-server to v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "0.0.0-experimental-e33071c6-20260224",
         "react-dom": "0.0.0-experimental-e33071c6-20260224",
-        "vite-plugin-react-server": "1.2.3"
+        "vite-plugin-react-server": "^1.4.0"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.3.6",
+        "vite-plugin-react-server": "^1.4.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8884,9 +8884,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.3.6.tgz",
-      "integrity": "sha512-lyvyd7LXQDZERHNHOT9jHzQxb+ibhgsZ25rG1lZBeEAqnJr6nx2NgRsxIEENng9ex+R/Ruk/q84Y1MU06heJYQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.0.tgz",
+      "integrity": "sha512-CvjsLEuLZf5wse5T+nHJXDkH4GV8RxATbCSTr/28Rye9i8gle637f6nqNWTP+tJ4Tr+cB5v8D72zp2ForStwuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "vite-css-modules": "^1.8.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3",
-    "vite-plugin-react-server": "^1.3.6"
+    "vite-plugin-react-server": "^1.4.0"
   },
   "include": [
     "src"
@@ -129,7 +129,7 @@
     "react-dom": "$react-dom"
   },
   "dependencies": {
-    "vite-plugin-react-server": "1.2.3",
+    "vite-plugin-react-server": "^1.4.0",
     "react": "0.0.0-experimental-e33071c6-20260224",
     "react-dom": "0.0.0-experimental-e33071c6-20260224"
   },


### PR DESCRIPTION
Bumps vite-plugin-react-server to v1.4.0

Changes in v1.4.0:
- Fix: server environment no longer triggers page reload for client component changes
- Fix: CSS changes trigger RSC refetch (inlined styles handled correctly)
- Fix: Migrated HMR from legacy handleHotUpdate to Vite 6 per-environment hotUpdate API