### PR TITLE
chore: bump vite-plugin-react-server to 1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "0.0.0-experimental-e33071c6-20260224",
         "react-dom": "0.0.0-experimental-e33071c6-20260224",
-        "vite-plugin-react-server": "^1.4.1"
+        "vite-plugin-react-server": "^1.4.2"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.4.1",
+        "vite-plugin-react-server": "^1.4.2",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8884,9 +8884,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.1.tgz",
-      "integrity": "sha512-tzGaN97/fNEGlx6pWzdtCLIRyk+BITZk9v/FI8T5IymwHVeHAyRSGNtaN1UvDE6KvJFyo2y3WdtCv7+uTiGZdw==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.2.tgz",
+      "integrity": "sha512-SSPFEefBxHL9FtFDnJitVYZipUsb+S2N9h5sBdC7YRxbxIQn5Y9lvE6Ak28eofW8ljdbffmkFAtWecD/JAZk5Q==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "vite-css-modules": "^1.8.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3",
-    "vite-plugin-react-server": "^1.4.1"
+    "vite-plugin-react-server": "^1.4.2"
   },
   "include": [
     "src"
@@ -129,7 +129,7 @@
     "react-dom": "$react-dom"
   },
   "dependencies": {
-    "vite-plugin-react-server": "^1.4.1",
+    "vite-plugin-react-server": "^1.4.2",
     "react": "0.0.0-experimental-e33071c6-20260224",
     "react-dom": "0.0.0-experimental-e33071c6-20260224"
   },


### PR DESCRIPTION
Bumps vite-plugin-react-server from 1.4.1 to 1.4.2. Includes HMR, request info, and .client.tsx detection fixes.