### PR TITLE
chore: bump vite-plugin-react-server to v1.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "react": "0.0.0-experimental-e33071c6-20260224",
         "react-dom": "0.0.0-experimental-e33071c6-20260224",
-        "vite-plugin-react-server": "^1.4.2"
+        "vite-plugin-react-server": "^1.4.3"
       },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.4.2",
+        "vite-plugin-react-server": "^1.4.3",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8884,11 +8884,16 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.2.tgz",
-      "integrity": "sha512-SSPFEefBxHL9FtFDnJitVYZipUsb+S2N9h5sBdC7YRxbxIQn5Y9lvE6Ak28eofW8ljdbffmkFAtWecD/JAZk5Q==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.3.tgz",
+      "integrity": "sha512-ubCeHkZAEgEfD6Rhg/xfYEaydEZ95HAkYNaCXHkGle2O8z3i5MtffgnOVAVvrWOYng6sPYWA3X17uBOHimKu4w==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "picocolors": "^1.1.1",
+        "tsx": "^4.21.0"
+      },
       "bin": {
         "check-react-version": "scripts/check-react-version.mjs",
         "patch": "bin/patch.mjs"

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "vite-css-modules": "^1.8.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3",
-    "vite-plugin-react-server": "^1.4.2"
+    "vite-plugin-react-server": "^1.4.3"
   },
   "include": [
     "src"
@@ -129,7 +129,7 @@
     "react-dom": "$react-dom"
   },
   "dependencies": {
-    "vite-plugin-react-server": "^1.4.2",
+    "vite-plugin-react-server": "^1.4.3",
     "react": "0.0.0-experimental-e33071c6-20260224",
     "react-dom": "0.0.0-experimental-e33071c6-20260224"
   },


### PR DESCRIPTION
Bumps vite-plugin-react-server to v1.4.3.