### PR TITLE
chore: bump vite-plugin-react-server to v1.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.4.4",
+        "vite-plugin-react-server": "^1.4.6",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8883,9 +8883,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.4.tgz",
-      "integrity": "sha512-eHpS7ysv3D5fiVPSAGYs2ark9rHIxziRWlO1T7K9xSR08ih/afzjwEMWs/dJ3rMBd5UblcY+Bb7TFP+JTWPVSQ==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.6.tgz",
+      "integrity": "sha512-0QOid5AyBdLcAnZaKyJ7HaVCV1XLoiRjceDeSyUmJuVTJWWAOz9f3Rqd3FE8dkPkGoia4aehOZ5imWOi02wQEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.4.4",
+    "vite-plugin-react-server": "^1.4.6",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to v1.4.6.

Per `vite-plugin-react-server/docs/releasing.md` step 4.