### PR TITLE
chore: bump vite-plugin-react-server to ^1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.4.8",
+        "vite-plugin-react-server": "^1.5.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8883,15 +8883,16 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.4.8.tgz",
-      "integrity": "sha512-hshBdPbfpHhSvvJ+BQGEFZLYgCwYdjuJV5CJrdQO+bitr8D1xZ3nScL29J2btqn8cH1fsEyZ7pzh0joxCkjOHA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.0.tgz",
+      "integrity": "sha512-LkeSaCn2zTE5Yme+vnrQkFCOBvuh9sIw6SaE9RrjnYMbqwzmib585zy1RTlqcvA755K0dAgLrWR+t5/JJqPyjw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "tsx": "^4.21.0"
+        "tsx": "^4.21.0",
+        "vitefu": "^1.1.3"
       },
       "bin": {
         "check-react-version": "scripts/check-react-version.mjs",
@@ -9433,6 +9434,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitefu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/vitefu/-/vitefu-1.1.3.tgz",
+      "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "tests/deps/*",
+        "tests/projects/*",
+        "tests/projects/workspace/packages/*"
+      ],
+      "peerDependencies": {
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/vitest": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.4.8",
+    "vite-plugin-react-server": "^1.5.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary

- Bumps `vite-plugin-react-server` from `^1.4.8` to `^1.5.0`.
- vprs 1.5.0 adds Next.js parity for node_modules `"use client"` packages — component libraries that ship per-file `"use client"` directives can now be imported directly into a server component without a `.client.tsx` wrapper. Auto-detected via peer-deps; no config required.

## Test plan

- [x] `npm install` resolves to `vite-plugin-react-server@1.5.0` from registry
- [x] `npm run build` → 300 pages rendered in 5.0s, no regressions
- [ ] (post-merge) deploy pipeline green

🤖 Generated with [Claude Code](https://claude.com/claude-code)