### PR TITLE
chore: bump vite-plugin-react-server to ^1.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.5.1",
+        "vite-plugin-react-server": "^1.5.2",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8894,9 +8894,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.1.tgz",
-      "integrity": "sha512-YnlfZdigC7JX88YrLhRNm4WFZAQl4TQsN/RZ66dudj+GVk616SGXxbfhTHakD7xLZ18u/VX1l/bQfe4eFz7Obg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.2.tgz",
+      "integrity": "sha512-VtLda0qRFGYawkwG+GEnaX0TExWtWLM/G5HKUgfnQ+yG4c4SQRj+TBQPrRZzH4AGM0LgeYpjRB/9pRqbJqbjjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.5.1",
+    "vite-plugin-react-server": "^1.5.2",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary

- `vite-plugin-react-server`: `^1.5.1` → `^1.5.2`
- Picks up the dev:ssr CSS module HMR fix released in v1.5.2 — `*.module.css` edits in `npm run dev:ssr` now invalidate the SSR worker's Node-cached imports and apply on reload. Previously the rendered class hashes stayed at their pre-edit values, which matched the symptom seen during the FTP-deploy session on 2026-05-13.

## Test plan

- [x] `npm install` resolves cleanly to 1.5.2; no peer-dep conflicts
- [ ] `npm run dev:ssr`, edit a `*.module.css` file, reload — verify the change applies without class-hash drift
- [ ] `npm run build` still produces 300 pages cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)