### PR TITLE
feat: wire up vprs RSC HMR in client.tsx

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -8,6 +8,7 @@ import React, {
 } from "react";
 import { createRoot } from "react-dom/client";
 import { createReactFetcher } from "vite-plugin-react-server/utils";
+import { useRscHmr } from "virtual:react-server/hmr";
 import { baseURL } from "./config/env.client.js";
 import { ErrorMessage } from "./ErrorMessage.js";
 import "./globalStyles.css";
@@ -33,10 +34,9 @@ const Shell: React.FC<{
   const [storeData, setStoreData] =
     useState<React.Usable<unknown>>(initialServerData);
 
-  const navigate = useCallback((to: string) => {
-    if ("scrollTo" in window) window.scrollTo(0, 0);
+  const refetch = useCallback((to: string, scrollToTop = true) => {
+    if (scrollToTop && "scrollTo" in window) window.scrollTo(0, 0);
     startTransition(() => {
-      // Create new RSC data stream
       setStoreData(
         createReactFetcher({
           url: to,
@@ -57,10 +57,14 @@ const Shell: React.FC<{
           : e.state.to
       );
       console.log("navigating to", newTo);
-      return navigate(newTo);
+      return refetch(newTo);
     },
     window
   );
+
+  // RSC HMR: refetch the stream when server components or CSS modules change.
+  // scrollToTop=false preserves the user's scroll position across edits.
+  useRscHmr((url) => refetch(url, false));
 
   const content = use(storeData);
 

--- a/src/config/env.client.ts
+++ b/src/config/env.client.ts
@@ -3,12 +3,6 @@ import {
   createBaseURL,
 } from "vite-plugin-react-server/utils";
 
-declare global {
-  interface ImportMetaEnv {
-    PUBLIC_ORIGIN: string;
-  }
-}
-
 export const absoluteURL = createAbsoluteURL(
   import.meta.env.BASE_URL ?? "/",
   import.meta.env.PUBLIC_ORIGIN ?? "https://mmcelebration.com"

--- a/src/config/env.server.ts
+++ b/src/config/env.server.ts
@@ -5,7 +5,6 @@ import {
 
 declare global {
   interface ImportMetaEnv {
-    PUBLIC_ORIGIN: string;
     BASE_URL: string;
     NODE_ENV: string;
     DEV: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,6 +47,7 @@
     "types": [
       "@types/react/experimental",
       "vite/client",
+      "vite-plugin-react-server/virtual",
       "node"
     ],
     "typeRoots": [


### PR DESCRIPTION
## Summary

mmc's `src/client.tsx` had all the navigation/refetch infrastructure (`setStoreData` + `createReactFetcher`) but never bound it to vprs's HMR WebSocket event. Result: editing a server component or a `*.module.css` file in `npm run dev:rsc` or `dev:ssr` updated the server side correctly, but the browser never re-requested the RSC stream, so content stayed stale until a manual refresh.

This PR mirrors `bidoof-template`'s wire-up — which has been working reliably in CI for months — adapting it to mmc's existing `useEventListener` pattern.

### Changes

- **`src/client.tsx`**
  - Renames `navigate(to)` to `refetch(to, scrollToTop = true)`. Popstate handler now calls `refetch(newTo)` (default scrolls top, unchanged behavior). HMR calls `refetch(url, false)` so the user's scroll position is preserved across edits.
  - Imports `useRscHmr` from `virtual:react-server/hmr` and hooks it up.
- **`tsconfig.json`** — adds `vite-plugin-react-server/virtual` to the `types` array so TypeScript resolves the virtual module + the augmented `ImportMetaEnv.PUBLIC_ORIGIN`.
- **`src/config/env.client.ts`, `src/config/env.server.ts`** — drops the local `declare global { interface ImportMetaEnv { PUBLIC_ORIGIN: string } }` blocks now that vprs's `virtual.d.ts` is authoritative. The local declarations omitted `readonly` and conflicted with vprs's `readonly PUBLIC_ORIGIN: string`, producing `TS2687: All declarations of 'PUBLIC_ORIGIN' must have identical modifiers` once the virtual types were enabled.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` produces 300 static pages cleanly
- [ ] (manual) `npm run dev:rsc`, edit a `*.module.css`, observe the rule apply without manual refresh
- [ ] (manual) Same test under `npm run dev:ssr`
- [ ] (manual) Edit a server component (.tsx), observe RSC stream refetch and content update

🤖 Generated with [Claude Code](https://claude.com/claude-code)