### PR TITLE
chore: bump vite-plugin-react-server to ^1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.5.2",
+        "vite-plugin-react-server": "^1.6.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.5.2.tgz",
-      "integrity": "sha512-VtLda0qRFGYawkwG+GEnaX0TExWtWLM/G5HKUgfnQ+yG4c4SQRj+TBQPrRZzH4AGM0LgeYpjRB/9pRqbJqbjjQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.6.0.tgz",
+      "integrity": "sha512-v/ciDT9KfrnQzLweJGxYabW5Q3lGeHxBqUnohXOGQXNOllTyQOXcI1DIZceSCRK8vQjyCBgT/rybh1IBIxVukQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.5.2",
+    "vite-plugin-react-server": "^1.6.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.5.2` to `^1.6.0`.

1.6.0 ships a Vite ModuleRunner–based fetch transport for dev:ssr
(https://github.com/nicobrinkkemper/vite-plugin-react-server/pull/44).
Project source is loaded through Vite's transform pipeline instead of
Node's native ESM cache, so module-graph invalidation works per-module
and dev:ssr CSS edits no longer trigger a full worker restart — dev:ssr
is now at parity with dev:rsc on save latency.

mmc uses the tracked-import CSS pattern (`import styles from
"./X.module.css"`), which the runner-mode CSS bridge handles natively
via Vite's server-environment module graph. The default-on runner was
locally verified against this very project via `npm link` before the
upstream tag.

Opt-out hatch: set `VPRS_RUNNER=0` in the environment if a
runner-specific regression appears.

## Test plan
- [x] `npm install` clean (small lockfile delta — 5 insertions).
- [x] `npm run build` — 300 static pages rendered in 6.71s, no errors.
- [ ] CI passes.
- [ ] Local dev:rsc + dev:ssr CSS edit smoke once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)