### PR TITLE
chore: bump vite-plugin-react-server to ^1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.6.0",
+        "vite-plugin-react-server": "^1.7.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.6.0.tgz",
-      "integrity": "sha512-v/ciDT9KfrnQzLweJGxYabW5Q3lGeHxBqUnohXOGQXNOllTyQOXcI1DIZceSCRK8vQjyCBgT/rybh1IBIxVukQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.0.tgz",
+      "integrity": "sha512-kytKXsP7p34tHbDlcxuiovrT7nAhjKNll54UQzyLXo51n7QcG4A4eWnAgpNmW1Z9vORfapf1faNnkGM9mmTSCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.6.0",
+    "vite-plugin-react-server": "^1.7.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary

Bumps \`vite-plugin-react-server\` from \`^1.6.0\` to \`^1.7.0\`.

1.7.0 is a cleanup release: removes the legacy non-runner code
paths and the Node ESM CSS/react/env loader registrations now that
the Vite ModuleRunner is the sole dev:ssr loader (upstream PR #47).

The undocumented \`VPRS_RUNNER=0\` opt-out introduced in 1.6.0 is
gone — mmc never set it, so this is a no-op for runtime behaviour.

## Test plan
- [x] \`npm install\` clean.
- [x] \`npm run build\` — 300 static pages rendered in 5.39s.
- [ ] CI passes.
- [ ] Local dev:rsc + dev:ssr smoke once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)