### PR TITLE
chore: bump vite-plugin-react-server to ^1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.7.1",
+        "vite-plugin-react-server": "^1.8.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.7.1.tgz",
-      "integrity": "sha512-b/id/q1ztgG+DcJOIi1XBoqu8xW2g2H06/ulGJTdS4NmWpb8YzkDgAFX7waxSwyBN21sXytpyD9MobF/X8xElw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.8.0.tgz",
+      "integrity": "sha512-hv56grbQ/S3tVl014Agj68JmtaBmhKYoL+OlKbKofqg1Rde7BlTRkZA5DSyPKP5CXn9DGXSdZqN8FBfV1y2c4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.7.1",
+    "vite-plugin-react-server": "^1.8.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary

Bumps `vite-plugin-react-server` from `^1.7.1` to `^1.8.0`.

1.8.0 is an additive, non-breaking minor: it adds an opt-in `./utils/rsc-client` subpath and hosts the vendored `react-server-dom-esm` (including a proper ESM `client.browser` entry) under public subpaths. Nothing mmc imports changes — this is purely picking up the new release.

## Test plan

- [x] `npm install` clean (vprs 1.8.0)
- [x] `npm run build` — 300 pages rendered
- [x] `npm test` — startup loader runs, vitest 2/2 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)