### PR TITLE
chore: bump vite-plugin-react-server to ^1.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.9.0",
+        "vite-plugin-react-server": "^1.10.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.9.0.tgz",
-      "integrity": "sha512-kE0BvJUZfEjznCNhVyrwZVpiynPFsnrewlLbrG5A6DFsr/U8/dnIBrUDnaIDLwbotAe7sxLqe49B1ruVQLTjng==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.10.0.tgz",
+      "integrity": "sha512-rMRPPnuGoIGgpN/LEwRHoJPEKyNv0z4kkSwgXV9RCfckK7lzSONsy6Hi0ZSfF+J/0g6d2l47V+H9TE7e15Qx7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.9.0",
+    "vite-plugin-react-server": "^1.10.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Summary
Bump `vite-plugin-react-server` from `^1.9.0` to `^1.10.0` (devDependencies) and refresh the lockfile.

vite-plugin-react-server 1.10.0 brings:
- Directive-based `"use client"` hosting: a top-of-file `"use client"` directive is now detected, hosted, and emitted as a client chunk in the static build — the `.client.` filename suffix is no longer required.
- A fix for compound client filenames (e.g. `X.Y.tsx`) in the static build.

This bump picks those up.

## Test plan
- [x] `npm install` updates `package-lock.json`; installed version confirmed `1.10.0`.
- [x] `npm run build` succeeds (300 static pages rendered, build green).