### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.10.0",
+        "vite-plugin-react-server": "^1.11.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.10.0.tgz",
-      "integrity": "sha512-rMRPPnuGoIGgpN/LEwRHoJPEKyNv0z4kkSwgXV9RCfckK7lzSONsy6Hi0ZSfF+J/0g6d2l47V+H9TE7e15Qx7A==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.0.tgz",
+      "integrity": "sha512-dkQ5NiTW3R/q9w9G0hmQrh1qnEEBuD4HniU7+YkrOEZsmxD2F2ycufxrRdRiOQcK4+vMPDlVy5VTMg8qkuZ8bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.10.0",
+    "vite-plugin-react-server": "^1.11.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` devDependency from `^1.10.0` to `^1.11.0`.

## Headlines from 1.11.0

- **Storybook static build fix.** `storybook build` previously broke for any vprs consumer (dangling `virtual:react-server/hmr` import, manager never booted). Now resolved via a `resolveId` + `load` stub. Affects Chromatic / hosted Storybook / visual-regression pipelines.
- **Unified client-module detector.** The 11 places across the plugin that each answered "is this a client module?" now route through one helper. Default behaviour tightened: the `loader.isClientComponent*` defaults moved from a loose substring matcher to the strict `.client.[cm]?[jt]sx?$` filename OR top-of-file `"use client"` directive form. Consumers using the canonical conventions (every realistic case) are unaffected; the loose default was an accidental footgun.
- **`await worker.terminate()`** in the static-build cleanup finally blocks. Eliminates a post-build async leak where libuv-level handles in the worker could fire after the build's promise resolved, racing the caller's cwd restoration and producing intermittent post-teardown errors.
- `createRollupLikeHash` dedup (internal), new docs page on module-resolution escape hatches.

## Verification

- `npm install` updated lockfile cleanly.
- Installed version confirmed as `1.11.0`.
- `npm run build` (full `vite build --app` with react-server condition + static prerender of 300 pages) completed successfully in ~5s.