### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.11.0",
+        "vite-plugin-react-server": "^1.11.1",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.0.tgz",
-      "integrity": "sha512-dkQ5NiTW3R/q9w9G0hmQrh1qnEEBuD4HniU7+YkrOEZsmxD2F2ycufxrRdRiOQcK4+vMPDlVy5VTMg8qkuZ8bg==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.1.tgz",
+      "integrity": "sha512-jwHCxAwzCvroL7zGZZdUn6tPU5z6Jp7te5nRQj7OGQETR/W2uWRrs3Fl9Mjiv95gRPMXdLt/cJNZ3hIGnvm1EQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.11.0",
+    "vite-plugin-react-server": "^1.11.1",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Picks up the 1.11.1 hotfix that fixes the missing `@font-face` regression on `src/client.tsx`-style entries.

Build passes locally.