### PR TITLE
fix(config): set clientEntry: src/client.tsx so vprs links globalStyles.css

### DIFF
--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -59,6 +59,13 @@ export const config = {
   props: createRouter("props.ts"),
   Root: "src/MmcRoot.tsx",
   Html: "src/MmcHtml.tsx",
+  // Tell vprs which file is the client hydration entry. Without this,
+  // its globalCss collection (processCssFilesForPages.ts) has no
+  // clientEntry to scan, so client.tsx's `import "./globalStyles.css"`
+  // never reaches the static HTML's <Css cssFiles={globalCss} />.
+  // Result: built globalStyles-*.css contains the @font-face rules but
+  // no <link> in the rendered HTML — fonts silently fail.
+  clientEntry: "src/client.tsx",
   pageExportName: "Page",
   propsExportName: "props",
   htmlExportName: "Html",


### PR DESCRIPTION
## Summary

8mmc and every other page render without our custom fonts on the deploy. `src/client.tsx` imports `./globalStyles.css` (7 `@font-face` declarations), but vprs's static-build CSS pipeline doesn't inject that file into the rendered HTML.

## Why

vprs's `processCssFilesForPages.ts` builds the `globalCss` prop from two sources: the static manifest's `index.html` entry, and an explicit `userOptions.clientEntry`. We don't ship a real `index.html` anymore (vprs generates the static HTML through `MmcHtml`), and we didn't set `clientEntry`. With both inputs empty, `globalCss` is empty, the `<Css cssFiles={globalCss} />` in `MmcHtml` renders nothing, and `globalStyles-*.css` — built correctly with all 7 `@font-face` declarations — has no `<link>` referencing it.

## Fix

Add `clientEntry: "src/client.tsx"` to the vprs options.

## Verification (local build)

```bash
$ grep globalStyles dist/static/8mmc/index.html
href="/assets/globalStyles-rszm1l.css"

$ grep -c @font-face dist/static/assets/globalStyles-rszm1l.css
7
```

## Follow-up (not in this PR)

A proper vprs-side fix would auto-detect the conventional `src/client.tsx` filename and feed it into `globalCssInputs` when `clientEntry` is not explicitly set — so every consumer doesn't have to add this one-liner manually. That'll come as a separate vprs PR.