### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.2, drop clientEntry workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.11.1",
+        "vite-plugin-react-server": "^1.11.2",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.1.tgz",
-      "integrity": "sha512-jwHCxAwzCvroL7zGZZdUn6tPU5z6Jp7te5nRQj7OGQETR/W2uWRrs3Fl9Mjiv95gRPMXdLt/cJNZ3hIGnvm1EQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.2.tgz",
+      "integrity": "sha512-o9EKmEvKSTtvHrBhYSwdjvfvckylHz/5GcBYfRqd1nrikf4ED0dyZrKHeDQUZsM+y1fE+Ep1P4qEgRXybf3b6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.11.1",
+    "vite-plugin-react-server": "^1.11.2",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -59,13 +59,6 @@ export const config = {
   props: createRouter("props.ts"),
   Root: "src/MmcRoot.tsx",
   Html: "src/MmcHtml.tsx",
-  // Tell vprs which file is the client hydration entry. Without this,
-  // its globalCss collection (processCssFilesForPages.ts) has no
-  // clientEntry to scan, so client.tsx's `import "./globalStyles.css"`
-  // never reaches the static HTML's <Css cssFiles={globalCss} />.
-  // Result: built globalStyles-*.css contains the @font-face rules but
-  // no <link> in the rendered HTML — fonts silently fail.
-  clientEntry: "src/client.tsx",
   pageExportName: "Page",
   propsExportName: "props",
   htmlExportName: "Html",


### PR DESCRIPTION
Pick up vprs 1.11.2's auto-detection of the client hydration entry from `index.html` `<script>` srcs. With that fix in place, the explicit `clientEntry: "src/client.tsx"` added in #102 as a workaround is no longer needed — globalStyles still resolves to a `<link>` in the rendered HTML.

Verified locally: `npm run build` passes and `dist/static/8mmc/index.html` still contains `href="/assets/globalStyles-rszm1l.css"`.