### PR TITLE
ci: bump GH Actions to versions on Node 24

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: '23.8.0'
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
       - run: npm ci
       - run: npm run startup:gh
       - run: npm run build:gh --if-present
@@ -36,7 +36,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/static
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
GitHub Actions runners are deprecating Node 20 for the JS-action wrapper layer (forced default 2026-06-16, removal 2026-09-16). Each of the five actions in this workflow had at least one major behind:

| action | was | now |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-node | v3 | v6 |
| actions/configure-pages | v4 | v6 |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |

Project Node stays at `23.8.0` — this is the action-wrapper Node version, not the project's.