### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.11.2",
+        "vite-plugin-react-server": "^1.11.3",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.2.tgz",
-      "integrity": "sha512-o9EKmEvKSTtvHrBhYSwdjvfvckylHz/5GcBYfRqd1nrikf4ED0dyZrKHeDQUZsM+y1fE+Ep1P4qEgRXybf3b6w==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.3.tgz",
+      "integrity": "sha512-JM4fpBC/Z+jGbHTFsT3PITRPAqzXKPGPcXCLpPdP9Fyezp7rQGrjyYn6u3DM+glLglQzQjIPUCW6kk6eGkivCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.11.2",
+    "vite-plugin-react-server": "^1.11.3",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Picks up the dev-server fix for bd-2dd (clientPackages root `optimizeDeps.exclude`, vprs PR #76). Also includes the Node floor README correction to 22.0.0 (#75) and drops a stray entrypoint `console.log` (#74).

Verified locally: installed 1.11.3, clean build passes, `dist/static/8mmc/index.html` still emits the `globalStyles` stylesheet link.