### PR TITLE
chore: bump vite-plugin-react-server to ^1.11.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^1.11.3",
+        "vite-plugin-react-server": "^1.11.4",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -8972,9 +8972,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.3.tgz",
-      "integrity": "sha512-JM4fpBC/Z+jGbHTFsT3PITRPAqzXKPGPcXCLpPdP9Fyezp7rQGrjyYn6u3DM+glLglQzQjIPUCW6kk6eGkivCA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-1.11.4.tgz",
+      "integrity": "sha512-LAtwRA1dkWTUm/yuDswmrvz+TFYKWEVSejGrq8ZhgxFbfo2vM27fCs6dFzAjqC4s9tuRgMrSg6IMvKQ9Rgt2Iw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^1.11.3",
+    "vite-plugin-react-server": "^1.11.4",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from `^1.11.3` to `^1.11.4`, which ships PR #78 (per-environment `resolve.conditions`). This fixes the client-interop regression (bd-dc0) while preserving the 1.11.3 server-side fix (bd-2dd).

Side benefit: plain `npm run dev` now works without the global `NODE_OPTIONS='--conditions react-server'` flag.