### PR TITLE
feat: React Fast Refresh + vite-plugin-react-server 2.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.3",
+        "vite-plugin-react-server": "^2.0.4",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.3.tgz",
-      "integrity": "sha512-bJOqxMHTntA2wowswO8YhA3hgc9UO0ooXiNSkeqTkVVgZSKbgFmCvjrKS+rerMMzZKFNlflNQCf6m5DH3Kl5uA==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.4.tgz",
+      "integrity": "sha512-Pwny32txYojazP+kxbCJzlbiPMCwGDeVuCIH+DcDbbAk/wQbBUOx/yFyO84prd038lU4SRZH2Zcpfbj3ERRv0Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.2",
+        "vite-plugin-react-server": "^2.0.3",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.2.tgz",
-      "integrity": "sha512-b0G3wAVKTU1W1iSgOeLStEi6mFIhWF5r6I0bWglXQA+tg0HgtfD8baQdOj7ndQ4b3eSvFl/C+FllBXMv3WsKgg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.3.tgz",
+      "integrity": "sha512-bJOqxMHTntA2wowswO8YhA3hgc9UO0ooXiNSkeqTkVVgZSKbgFmCvjrKS+rerMMzZKFNlflNQCf6m5DH3Kl5uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.1",
+        "vite-plugin-react-server": "^2.0.2",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.1.tgz",
-      "integrity": "sha512-tbqPdjPTL/GkeCUwGf4tw1gPvboLsjn4j6fSCZ7rsUs66QIp7iZTj6SNQ3i+kMKTBzaoJ1WmyFvQizqjOYcmWQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.2.tgz",
+      "integrity": "sha512-b0G3wAVKTU1W1iSgOeLStEi6mFIhWF5r6I0bWglXQA+tg0HgtfD8baQdOj7ndQ4b3eSvFl/C+FllBXMv3WsKgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.4",
+        "vite-plugin-react-server": "^2.0.5",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.4.tgz",
-      "integrity": "sha512-Pwny32txYojazP+kxbCJzlbiPMCwGDeVuCIH+DcDbbAk/wQbBUOx/yFyO84prd038lU4SRZH2Zcpfbj3ERRv0Q==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.5.tgz",
+      "integrity": "sha512-VRjQUB0O8oIWxa1b4C3O56BiFEPm1oD4l6WpP5cxH/D2MtvMfbO+cXeTWzI7kvClyfp7SmRhW5810xclmV9VtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.2",
+    "vite-plugin-react-server": "^2.0.3",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.3",
+    "vite-plugin-react-server": "^2.0.4",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.4",
+    "vite-plugin-react-server": "^2.0.5",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.1",
+    "vite-plugin-react-server": "^2.0.2",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, type Plugin } from "vite";
+import react from "@vitejs/plugin-react";
 import { vitePluginReactServer } from "vite-plugin-react-server";
 import { config } from "./vite.react.config.js";
 
@@ -33,6 +34,9 @@ export default defineConfig(() => {
   return {
     base: process.env.BASE_URL || "/",
     plugins: [
+      // `react()` before vitePluginReactServer(): client-component Fast Refresh
+      // (state-preserving hot updates); vprs owns server-component HMR.
+      react(),
       trailingSlashPlugin(),
       ...(vitePluginReactServer(config) as Plugin[]),
     ],


### PR DESCRIPTION
Adopts React Fast Refresh for client components and brings the example up to the latest vite-plugin-react-server.

- `react()` is placed **before** `vitePluginReactServer()` so client components get state-preserving hot updates (Fast Refresh), while vprs owns server-component HMR (RSC refetch).
- Bumps `vite-plugin-react-server` `^2.0.1` → `^2.0.5`, picking up: Fast Refresh under RSC (keep client-ref ids `.tsx` in dev), the dev:ssr full-reload fix, and the dev-mode static build fixes (client-ref/emit parity, server-bundle JSX transform, and `mode` mirroring `NODE_ENV`).

Builds clean (`vite build --app`) on 2.0.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)