### PR TITLE
chore: bump vite-plugin-react-server to 2.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.5",
+        "vite-plugin-react-server": "^2.0.6",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.5.tgz",
-      "integrity": "sha512-VRjQUB0O8oIWxa1b4C3O56BiFEPm1oD4l6WpP5cxH/D2MtvMfbO+cXeTWzI7kvClyfp7SmRhW5810xclmV9VtQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.6.tgz",
+      "integrity": "sha512-es8Xa6ITynGGWGjTAY6E1CT4TaXVMi/B3/8XOzPgu1+HA4JesyXkJIQ7X1WK6veNEyaIeHilAMHOJNKwtEs0Uw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.5",
+    "vite-plugin-react-server": "^2.0.6",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` `^2.0.5` → `^2.0.6`, which fixes the static/no-backend freeze: the headless per-route `.rsc` no longer carries the full `<html>` document (so the browser client mounts page content into `#root` instead of nesting `<html>` in a `<div>`), and the vendored rsdom browser client resolves its dev/prod variant from the mirrored mode.

Builds clean (`vite build --app`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)