### PR TITLE
chore: bump vite-plugin-react-server to 2.0.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.6",
+        "vite-plugin-react-server": "^2.0.7",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.6.tgz",
-      "integrity": "sha512-es8Xa6ITynGGWGjTAY6E1CT4TaXVMi/B3/8XOzPgu1+HA4JesyXkJIQ7X1WK6veNEyaIeHilAMHOJNKwtEs0Uw==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
+      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.6",
+    "vite-plugin-react-server": "^2.0.7",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps vprs `^2.0.6` → `^2.0.7` for the **dev:rsc client-graph CSS HMR fix**: editing a CSS module reached through a `"use client"` component now hot-updates in dev instead of requiring a manual refresh. Build verified with 2.0.7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)