### PR TITLE
chore: bump vite-plugin-react-server to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.7",
+        "vite-plugin-react-server": "^2.0.8",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
-      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.8.tgz",
+      "integrity": "sha512-ye2s2fWnHFMkdUvPRvd7qyHujIBvlKjM/fxReN47hz/n/E2813zQjG0dNV/8bP31TvHKPpJL1MBa5nMTdD+zqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.7",
+    "vite-plugin-react-server": "^2.0.8",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` to **^2.0.8**, picking up the dev:ssr client-graph CSS HMR fix (vprs #98) — client-graph CSS modules now hot-update under `dev:ssr` without a manual refresh.

Build verified: `npm run build` renders all 300 static pages clean against 2.0.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)