### PR TITLE
vprs 2.0.8 + experimental React train (restores CSS preloading)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,8 @@
         "markdown-to-jsx": "^7.7.2",
         "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "0.0.0-experimental-900ae094-20260605",
+        "react-dom": "0.0.0-experimental-900ae094-20260605",
         "sharp": "^0.33.5",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
@@ -7285,9 +7285,9 @@
       }
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "version": "0.0.0-experimental-900ae094-20260605",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-900ae094-20260605.tgz",
+      "integrity": "sha512-fjgJ6kbV68FlZ26ymAu2TOqcXs5qsXVcwPe6c1DR7bouUKN3EpOL+5SLU/JTSLoFzaJQcjJp5VbcKhrD0SWQ6g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7295,16 +7295,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "version": "0.0.0-experimental-900ae094-20260605",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-900ae094-20260605.tgz",
+      "integrity": "sha512-Cf4TCi4hU9s5sxJ5H4fHbN2qAcL+ZqHuEp7aOtqAEpQESJQ2BQ5iGTKp1aahtRhUqXMHKuyNTNZelXOCY042+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.27.0"
+        "scheduler": "0.0.0-experimental-900ae094-20260605"
       },
       "peerDependencies": {
-        "react": "^19.2.7"
+        "react": "0.0.0-experimental-900ae094-20260605"
       }
     },
     "node_modules/react-is": {
@@ -7323,35 +7323,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-server-loader": {
-      "version": "19.2.8",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-19.2.8.tgz",
-      "integrity": "sha512-4xYQ2QkP24Jw49hkrVXCjn97Jg1RpNS20n+kqINhABvgNgD8SKYWBNfaXiPGZg2ZfGvqgPTSZm2bHulD1eACDg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.16.0",
-        "picocolors": "^1.1.1",
-        "source-map": "^0.7.6"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7"
-      }
-    },
-    "node_modules/react-server-loader/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/read-pkg": {
@@ -7693,9 +7664,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "version": "0.0.0-experimental-900ae094-20260605",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-900ae094-20260605.tgz",
+      "integrity": "sha512-ezoF3d9EWBYtnAfbgGzWt8nbd/wS7APKeUtA1RvZO0ywsmR8u5AqFGoVD4FwSV76Abzrmi3hwT01+O5NEEbWYg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9031,6 +9002,35 @@
         "vite": {
           "optional": false
         }
+      }
+    },
+    "node_modules/vite-plugin-react-server/node_modules/react-server-loader": {
+      "version": "0.0.0-experimental-900ae094-20260605",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-900ae094-20260605.tgz",
+      "integrity": "sha512-nxNu6Wzc8ZyU6lb7O8cgBjcEj+XFiUgKZIn5bOp/yiPwrBV+FQ6HwnMKZLlyb0AiWixguXM+6YXzJlwL0eSUOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "picocolors": "^1.1.1",
+        "source-map": "^0.7.6"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "react": "0.0.0-experimental-900ae094-20260605",
+        "react-dom": "0.0.0-experimental-900ae094-20260605"
+      }
+    },
+    "node_modules/vite-plugin-react-server/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/vite/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.0.7",
+        "vite-plugin-react-server": "^2.0.8",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9001,9 +9001,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.7.tgz",
-      "integrity": "sha512-yrf0BIa31wUZaDODbXzVmdZPHZMAizLLGejEWXI3m51MCoYfT3WH9RitxlVNe0fW8sW25OyWNlAKBRAXd3gctg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.0.8.tgz",
+      "integrity": "sha512-ye2s2fWnHFMkdUvPRvd7qyHujIBvlKjM/fxReN47hz/n/E2813zQjG0dNV/8bP31TvHKPpJL1MBa5nMTdD+zqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -114,8 +114,8 @@
     "markdown-to-jsx": "^7.7.2",
     "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "0.0.0-experimental-900ae094-20260605",
+    "react-dom": "0.0.0-experimental-900ae094-20260605",
     "sharp": "^0.33.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
@@ -132,6 +132,7 @@
   ],
   "overrides": {
     "react": "$react",
-    "react-dom": "$react-dom"
+    "react-dom": "$react-dom",
+    "react-server-loader": "0.0.0-experimental-900ae094-20260605"
   }
 }

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.0.7",
+    "vite-plugin-react-server": "^2.0.8",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
## Why

Since the vprs 2.0 move to stable React, CSS preloading has been broken: stable React 19.2.x renders preload hints as `<link rel="preload" as="stylesheet">` — an invalid `as` value — so browsers drop the hint entirely and log the well-known console warning. The experimental React channel already carries the fix (`as="style"`). The pre-2.0 production build at https://mmcelebration.com/ (experimental React) is the working baseline.

This site leans on CSS preloading, so it moves to the experimental train. bidoof-template inlines its small CSS and stays on stable — between the two we now exercise both react-server-loader trains.

## What

- Bump `vite-plugin-react-server` to 2.0.8 (carries the pending chore branch).
- Pin `react` / `react-dom` to `0.0.0-experimental-900ae094-20260605` — the exact build `react-server-loader@experimental` was vendored against (its peer range pins it).
- Add the `overrides` entry from vprs's `docs/react-type-compatibility.md` routing the plugin's nested `react-server-loader` to the same experimental version. `npm ls` confirms a single, overridden copy — the plugin's own stable pin no longer materializes.

## Verification

- `npm test` green.
- Full `vite build --app` (300 prerendered pages) clean — no React warnings.
- dist HTML emits valid `<link rel="preload" … as="style">`; an A/B build of the same tree on stable React emits the broken `as="stylesheet"` form, confirming attribution.
- Image preloads and precedence-managed stylesheets byte-match the production baseline shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)