### PR TITLE
chore: update to vprs 2.3.0 + refreshed experimental React

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,9 +38,9 @@
         "markdown-to-jsx": "^7.7.2",
         "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
-        "react": "0.0.0-experimental-900ae094-20260605",
-        "react-dom": "0.0.0-experimental-900ae094-20260605",
-        "react-server-loader": "0.0.0-experimental-900ae094-20260605",
+        "react": "0.0.0-experimental-d9158919-20260615",
+        "react-dom": "0.0.0-experimental-d9158919-20260615",
+        "react-server-loader": "0.0.0-experimental-d9158919-20260615",
         "sharp": "^0.33.5",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.2.0",
+        "vite-plugin-react-server": "^2.3.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -7286,9 +7286,9 @@
       }
     },
     "node_modules/react": {
-      "version": "0.0.0-experimental-900ae094-20260605",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-900ae094-20260605.tgz",
-      "integrity": "sha512-fjgJ6kbV68FlZ26ymAu2TOqcXs5qsXVcwPe6c1DR7bouUKN3EpOL+5SLU/JTSLoFzaJQcjJp5VbcKhrD0SWQ6g==",
+      "version": "0.0.0-experimental-d9158919-20260615",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-d9158919-20260615.tgz",
+      "integrity": "sha512-XB3kpHdzfFQs/kj+rernMVQC9Nrt7ToSViho4yLLCp9WAKrpiTfDGPNA5ozQ7PDMw7npVetGXuX3MWKbwc40uw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7296,16 +7296,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "0.0.0-experimental-900ae094-20260605",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-900ae094-20260605.tgz",
-      "integrity": "sha512-Cf4TCi4hU9s5sxJ5H4fHbN2qAcL+ZqHuEp7aOtqAEpQESJQ2BQ5iGTKp1aahtRhUqXMHKuyNTNZelXOCY042+g==",
+      "version": "0.0.0-experimental-d9158919-20260615",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-d9158919-20260615.tgz",
+      "integrity": "sha512-sHxXG/LmtS/tvckGrllFpPqdfIb7h3gcXzyq+PhqAeapPZfksILaxNUueqOh7Tuf5T1Qd//7LUTz86ZLNHQdmQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "0.0.0-experimental-900ae094-20260605"
+        "scheduler": "0.0.0-experimental-d9158919-20260615"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-900ae094-20260605"
+        "react": "0.0.0-experimental-d9158919-20260615"
       }
     },
     "node_modules/react-is": {
@@ -7327,9 +7327,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "0.0.0-experimental-900ae094-20260605",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-900ae094-20260605.tgz",
-      "integrity": "sha512-nxNu6Wzc8ZyU6lb7O8cgBjcEj+XFiUgKZIn5bOp/yiPwrBV+FQ6HwnMKZLlyb0AiWixguXM+6YXzJlwL0eSUOQ==",
+      "version": "0.0.0-experimental-d9158919-20260615",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-d9158919-20260615.tgz",
+      "integrity": "sha512-E6YwVX2+bMp0TxMmy8B297MQzuUaATkP/vAiSdz9rjBjrChzAS4Yq7lXgahxlQcmMM1pR4IODnpNIArbIsvqAA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7341,8 +7341,8 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-900ae094-20260605",
-        "react-dom": "0.0.0-experimental-900ae094-20260605"
+        "react": "0.0.0-experimental-d9158919-20260615",
+        "react-dom": "0.0.0-experimental-d9158919-20260615"
       }
     },
     "node_modules/react-server-loader/node_modules/source-map": {
@@ -7694,9 +7694,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.0.0-experimental-900ae094-20260605",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-900ae094-20260605.tgz",
-      "integrity": "sha512-ezoF3d9EWBYtnAfbgGzWt8nbd/wS7APKeUtA1RvZO0ywsmR8u5AqFGoVD4FwSV76Abzrmi3hwT01+O5NEEbWYg==",
+      "version": "0.0.0-experimental-d9158919-20260615",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-d9158919-20260615.tgz",
+      "integrity": "sha512-4Ku4WFsdKS/v8Afd0IOCoxZsnwU9GiOWHKqlmquPNAtpms3cGj3Yhz7Evamsgn1ztKZw0uSYZ7a5iPcPtiUeUA==",
       "dev": true,
       "license": "MIT"
     },
@@ -9002,15 +9002,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.2.0.tgz",
-      "integrity": "sha512-dX1hscB7YDbDBkwsuvRBmaoXn/4UQveqt1ku5CQ7s4OMeiIB/wZvqJADA/RRjPcUszHjKXydZxDlovRWFXLHYA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.0.tgz",
+      "integrity": "sha512-a3JlibPe8L43rk+o3R5q+PZGMjXUw8uvIWUF6Hp7A5sBOKxdCbNx4aThoWUJTLGBKWzGwbYusZuj9hkJb87JUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.8 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "markdown-to-jsx": "^7.7.2",
     "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
-    "react": "0.0.0-experimental-900ae094-20260605",
-    "react-dom": "0.0.0-experimental-900ae094-20260605",
-    "react-server-loader": "0.0.0-experimental-900ae094-20260605",
+    "react": "0.0.0-experimental-d9158919-20260615",
+    "react-dom": "0.0.0-experimental-d9158919-20260615",
+    "react-server-loader": "0.0.0-experimental-d9158919-20260615",
     "sharp": "^0.33.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.2.0",
+    "vite-plugin-react-server": "^2.3.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },
@@ -134,6 +134,6 @@
   "overrides": {
     "react": "$react",
     "react-dom": "$react-dom",
-    "react-server-loader": "0.0.0-experimental-900ae094-20260605"
+    "react-server-loader": "0.0.0-experimental-d9158919-20260615"
   }
 }


### PR DESCRIPTION
Brings mmc up to date.

- **vite-plugin-react-server** `^2.2.0` → `^2.3.0` (reference gate, client-imported server functions, sealed-gate helper).
- **react / react-dom / react-server-loader** `0.0.0-experimental-900ae094-20260605` → `0.0.0-experimental-d9158919-20260615`. mmc tracks the experimental train (its `clean-install` script installs `@experimental`); the three move in lockstep since experimental peers are exact-pinned.

**Verified:** `npm run build` SSGs all 300 pages clean against the new versions.

Note: mmc uses the prop-passing pattern for server actions, so it's unaffected by the dev-only client-import issue being fixed separately in vprs 2.3.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)