### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.3.0",
+        "vite-plugin-react-server": "^2.3.2",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.0.tgz",
-      "integrity": "sha512-a3JlibPe8L43rk+o3R5q+PZGMjXUw8uvIWUF6Hp7A5sBOKxdCbNx4aThoWUJTLGBKWzGwbYusZuj9hkJb87JUQ==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.2.tgz",
+      "integrity": "sha512-vCBOS07v2OPfrpnDJA96nVONviAXeAHkdY3NBHITmWijpdWaY12HMCP3UJ67xKGst8vgIE3rjXRM5hVqktfJew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.3.0",
+    "vite-plugin-react-server": "^2.3.2",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.3.0 to 2.3.2.

2.3.2 fixes a static-build hang: a `<Suspense>` boundary whose resolved content backpressured the HTML prerender lost the stream's `drain` event, so the build never settled and aborted at its timeout. The HTML worker now pipes into a real `node:stream.Writable`, restoring backpressure.

Verified locally: `npm run build` prerenders 300 pages, exit 0.