### PR TITLE
chore: vite-plugin-react-server 2.4.1 + flash-free first render

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.3.2",
+        "vite-plugin-react-server": "^2.4.1",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.3.2.tgz",
-      "integrity": "sha512-vCBOS07v2OPfrpnDJA96nVONviAXeAHkdY3NBHITmWijpdWaY12HMCP3UJ67xKGst8vgIE3rjXRM5hVqktfJew==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.4.1.tgz",
+      "integrity": "sha512-mTHxeGAmpcfH7QD0jEXodiddfv3LYcG0vOJ3lMrWHgDyVUvBENDipdmxeblx7f22KNH5GQ5ZZWr20XsoO9cVOw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.3.2",
+    "vite-plugin-react-server": "^2.4.1",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,12 +1,11 @@
 "use client";
 import React, {
-  use,
   useCallback,
   useState,
   useTransition,
   type ReactNode,
 } from "react";
-import { createRoot } from "react-dom/client";
+import { createRoot, hydrateRoot } from "react-dom/client";
 import { createReactFetcher } from "vite-plugin-react-server/utils";
 import { useRscHmr } from "virtual:react-server/hmr";
 import { baseURL } from "./config/env.client.js";
@@ -28,22 +27,25 @@ import { useEventListener } from "./hooks/useEventListener.js";
  * Handles navigation and RSC data updates
  */
 const Shell: React.FC<{
-  data: React.Usable<unknown>;
-}> = ({ data: initialServerData }) => {
+  initialNode: ReactNode;
+}> = ({ initialNode }) => {
   const [, startTransition] = useTransition();
-  const [storeData, setStoreData] =
-    useState<React.Usable<unknown>>(initialServerData);
+  const [content, setContent] = useState<ReactNode>(initialNode);
 
   const refetch = useCallback((to: string, scrollToTop = true) => {
     if (scrollToTop && "scrollTo" in window) window.scrollTo(0, 0);
-    startTransition(() => {
-      setStoreData(
-        createReactFetcher({
-          url: to,
-          moduleBaseURL: import.meta.env.BASE_URL,
-          publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-        })
-      );
+    // Resolve the next route's payload to a ReactNode *before* swapping it in,
+    // so the render stays synchronous (no Suspense boundary, no `use()`) and
+    // never flashes an empty tree — the same decode-then-render path as the
+    // initial mount below.
+    Promise.resolve(
+      createReactFetcher({
+        url: to,
+        moduleBaseURL: import.meta.env.BASE_URL,
+        publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+      })
+    ).then((node) => {
+      startTransition(() => setContent(node as ReactNode));
     });
   }, []);
 
@@ -66,21 +68,43 @@ const Shell: React.FC<{
   // scrollToTop=false preserves the user's scroll position across edits.
   useRscHmr((url) => refetch(url, false));
 
-  const content = use(storeData);
-
-  return <ErrorBoundary>{content as ReactNode}</ErrorBoundary>;
+  return <ErrorBoundary>{content}</ErrorBoundary>;
 };
 // Initialize the app
 const rootElement = document.getElementById("root");
 if (!rootElement) throw new Error("Root element not found");
 
-const intitalData = createReactFetcher({
-  url: window.location.pathname,
-  moduleBaseURL: import.meta.env.BASE_URL,
-  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-});
-
-createRoot(rootElement).render(<Shell data={intitalData} />);
+// Fully resolve the initial payload to a ReactNode *before* mounting, then
+// render that node directly — a synchronous first render with no Suspense
+// boundary, so hydrateRoot matches the prerendered HTML exactly. (Wrapping the
+// root in a <Suspense> the server never rendered, or `use()`-ing a pending
+// thenable, mismatches the prerender → React #418.) With the build's inlined
+// flight payload, createReactFetcher decodes in place with no network
+// round-trip; without it (e.g. dev) it falls back to fetching index.rsc.
+Promise.resolve(
+  createReactFetcher({
+    url: window.location.pathname,
+    moduleBaseURL: import.meta.env.BASE_URL,
+    publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+  })
+).then(
+  (initialNode) => {
+    // Hydrate the prerendered HTML when present; fall back to a fresh client
+    // render when #root is empty (e.g. dev without prerender).
+    if (rootElement.hasChildNodes()) {
+      hydrateRoot(rootElement, <Shell initialNode={initialNode as ReactNode} />);
+    } else {
+      createRoot(rootElement).render(
+        <Shell initialNode={initialNode as ReactNode} />
+      );
+    }
+  },
+  (err) => {
+    // Stay on the prerendered static HTML rather than mounting a broken tree;
+    // links fall back to normal full-page navigation.
+    console.error("[mmc] initial RSC payload failed to load; staying static", err);
+  }
+);
 
 /**
  * Error boundary

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,30 @@
+import { resolve } from "node:path";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { vitePluginReactServer } from "vite-plugin-react-server";
+import { inlineFlightPayload } from "vite-plugin-react-server/react-static/inlineFlightPayload";
 import { config } from "./vite.react.config.js";
+
+/**
+ * After vprs prerenders the site, inline each route's flight payload into its
+ * own HTML (a non-executable <script id="vprs-flight">) so the browser has the
+ * initial RSC payload at load. createReactFetcher consumes it on the first call
+ * instead of fetching index.rsc, which lets the client decode + hydrate in place
+ * with no network round-trip and no flash. Client navigations still fetch their
+ * target route's .rsc as before. staticDir matches the deploy artifact
+ * (scripts/deploy-ftp.mjs uploads dist/static).
+ */
+function inlineFlightPlugin(): Plugin {
+  return {
+    name: "mmc:inline-flight-payload",
+    async closeBundle() {
+      const count = await inlineFlightPayload({
+        staticDir: resolve("dist/static"),
+      });
+      console.log(`[mmc] inlined flight payload into ${count} page(s)`);
+    },
+  };
+}
 
 /**
  * Plugin to handle trailing slashes in preview mode.
@@ -39,6 +62,8 @@ export default defineConfig(() => {
       react(),
       trailingSlashPlugin(),
       ...(vitePluginReactServer(config) as Plugin[]),
+      // After vprs (closeBundle runs post-build, once static files exist).
+      inlineFlightPlugin(),
     ],
   };
 });


### PR DESCRIPTION
## What

- Bumps `vite-plugin-react-server` 2.3.2 → **2.4.1**.
- Adopts the flash-free first-render optimization from the vprs docs site.

## Why 2.4.1

2.4.1 fixes the `react-server` `/utils` barrel import-safety regression that hard-broke the experimental React train on 2.4.0. This app rides that train (`react@0.0.0-experimental-*`), so it was the affected consumer. With 2.4.1 the full app build renders all 300 pages clean.

## Flash-free first render

Previously the client did `createRoot(...).render()` with `use(thenable)` — it fetched `index.rsc` over the network and re-rendered over the prerendered HTML, causing a flash. Now:

- **Build** (`vite.config.ts`): a `closeBundle` plugin runs `inlineFlightPayload()` against `dist/static`, embedding each route's `index.rsc` into its `index.html` as a non-executable `<script id="vprs-flight">`. 300/300 pages inlined.
- **Client** (`src/client.tsx`): decode-then-hydrate — the initial payload is resolved to a `ReactNode` before mounting, then `hydrateRoot` hydrates the prerendered DOM in place (`createRoot` fallback when `#root` is empty, e.g. dev). No Suspense boundary on first paint, so hydration matches the prerender exactly (avoids React #418). Navigation resolves the next node before swapping it in.

The 2.4.1 `createReactFetcher` consumes the inline payload itself, so initial load issues **zero `.rsc` requests** and hydrates in place. A side effect: initial hydration no longer depends on the base path.

## Verification

Headless run against the built `dist/static`:

- Initial load: **0 `.rsc` requests**, content rendered, **0 hydration / console / page errors**.
- Client navigation: fetches the target route's `.rsc` with **no full page reload**.