### PR TITLE
chore: adopt vprs 2.6.0 build.inlineFlight, drop hand-rolled inline plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.5.0",
+        "vite-plugin-react-server": "^2.6.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.5.0.tgz",
-      "integrity": "sha512-me8UcfHcqx0WVjJ/ZPuRGXmMJMQZVF/2qZo6js7OkS6rOoruhv72cO1xidbaApABZas0nBEAzbVM8qeSGRr+3A==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.0.tgz",
+      "integrity": "sha512-xoTJlni0+JHgjcgq7fqtDvs+Q5zkKZAtyNyOPRS1Rqa0KbPECB+GbUJzRo2shKjyrxkOzTXJYmt4OyM3iMEBtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.5.0",
+    "vite-plugin-react-server": "^2.6.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,30 +1,7 @@
-import { resolve } from "node:path";
 import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import { vitePluginReactServer } from "vite-plugin-react-server";
-import { inlineFlightPayload } from "vite-plugin-react-server/react-static/inlineFlightPayload";
 import { config } from "./vite.react.config.js";
-
-/**
- * After vprs prerenders the site, inline each route's flight payload into its
- * own HTML (a non-executable <script id="vprs-flight">) so the browser has the
- * initial RSC payload at load. createReactFetcher consumes it on the first call
- * instead of fetching index.rsc, which lets the client decode + hydrate in place
- * with no network round-trip and no flash. Client navigations still fetch their
- * target route's .rsc as before. staticDir matches the deploy artifact
- * (scripts/deploy-ftp.mjs uploads dist/static).
- */
-function inlineFlightPlugin(): Plugin {
-  return {
-    name: "mmc:inline-flight-payload",
-    async closeBundle() {
-      const count = await inlineFlightPayload({
-        staticDir: resolve("dist/static"),
-      });
-      console.log(`[mmc] inlined flight payload into ${count} page(s)`);
-    },
-  };
-}
 
 /**
  * Plugin to handle trailing slashes in preview mode.
@@ -62,8 +39,6 @@ export default defineConfig(() => {
       react(),
       trailingSlashPlugin(),
       ...(vitePluginReactServer(config) as Plugin[]),
-      // After vprs (closeBundle runs post-build, once static files exist).
-      inlineFlightPlugin(),
     ],
   };
 });

--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -75,5 +75,8 @@ export const config = {
   },
   build: {
     pages: pages,
+    // Flash-free first render: vprs inlines each route's flight payload into its
+    // index.html at the post-SSG point, in both build modes (>= 2.6.0).
+    inlineFlight: true,
   },
 };


### PR DESCRIPTION
## What

vprs 2.6.0 inlines each route's flight payload itself, at the post-SSG point, in **both** build modes. So this app no longer needs its own `closeBundle` inline plugin (which only worked in server-first builds) or the `--conditions react-server` workaround in `build:prod`.

- bump `vite-plugin-react-server` `^2.5.0 → ^2.6.0`
- `vite.react.config`: `build.inlineFlight: true`
- `vite.config`: remove the `mmc:inline-flight-payload` `closeBundle` plugin + its now-unused imports
- `build:prod` no longer forces the react-server condition

## Why

The hand-rolled inline step ran from a `closeBundle`, which sees finalized HTML only in server-first builds; in client-first builds it ran before the deferred write and silently produced a non-flash-free build. Moving it into the plugin (vprs 2.6.0) makes the outcome identical in both modes.

## Verification

`build:prod` (client-first) and a server-first build both inline **300/300**; the output matches the previous closeBundle build. Headless against the build: 0 `.rsc` on initial load, content rendered, clean hydration.