### PR TITLE
fix: declare <meta charset=utf-8> so prerendered HTML decodes correctly

### DIFF
--- a/src/MmcHtml.tsx
+++ b/src/MmcHtml.tsx
@@ -24,6 +24,11 @@ export const Html: MmcHtmlType = ({
   return (
     <html>
       <head>
+        {/* Must be the first head element: declares the document encoding so the
+            browser decodes the prerendered UTF-8 HTML correctly even when the
+            host doesn't send a charset header. Without it, non-ASCII text (™, —)
+            decodes as Latin-1 and mismatches the client render (React #418). */}
+        <meta charSet="utf-8" />
         <Head
           title={pageProps.title}
           description={pageProps.description}


### PR DESCRIPTION
## Symptom

Every level page threw **React #418** (hydration mismatch) on a host that doesn't send a `charset` Content-Type header — consistently, 5/5 loads. Homepage was clean. (gh-pages was unaffected because GitHub Pages sends `charset=utf-8`.)

## Cause

Level pages contain non-ASCII text (`™`, `—`, … in maker descriptions). The prerendered HTML is correct UTF-8 on disk, but the document only carried a **non-standard `<meta name="html-charset">`** (browsers ignore it) — no real `<meta charset>`. So decoding depended on the host header. Without it, the browser decodes the bytes as Latin-1: `™` → `â„¢`, `—` → `â€”`. That server text mismatches the client render (which decodes the RSC flight as UTF-8) → #418.

This is independent of build mode and of `build.inlineFlight` (reproduced with inline off, both build modes, and with `startup` re-run under prod conditions).

## Fix

Add a real `<meta charSet="utf-8" />` as the first `<head>` child in `MmcHtml.tsx`, so the document self-declares its encoding regardless of host header.

## Verification

Served the local build under the `mmcelebration.com` origin (request routing) across homepage, theme/levels indexes, level pages (10mmc + 9mmc), and credits: **0 hydration errors, 0 initial `.rsc`, content + inline-flight on every route.** Was 5/5 #418 on level pages before the fix.