### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.6.0",
+        "vite-plugin-react-server": "^2.6.1",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.0.tgz",
-      "integrity": "sha512-xoTJlni0+JHgjcgq7fqtDvs+Q5zkKZAtyNyOPRS1Rqa0KbPECB+GbUJzRo2shKjyrxkOzTXJYmt4OyM3iMEBtw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.1.tgz",
+      "integrity": "sha512-PqZOlgj9nYdw6x4YxDojd/ssQL3ulZ2keAMNYgOQPhL37lZaFHxNp9lRJJieuJrWIA+p7dHRmDniMJAIi+Xavg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.6.0",
+    "vite-plugin-react-server": "^2.6.1",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 2.6.0 → **2.6.1**.

2.6.1 is a metadata-only patch: it fixes the root package entrypoints (`main`/`module`/`types` in 2.6.0 pointed at `dist/plugin/index.*`, which were absent from the tarball; now they point at the emitted `dist/index.*` and the root export gained a `types` condition). Runtime code is unchanged from 2.6.0.

Verified `npm install` resolves 2.6.1 with `main` pointing at an existing file.