### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.6.1",
+        "vite-plugin-react-server": "^2.7.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.6.1.tgz",
-      "integrity": "sha512-PqZOlgj9nYdw6x4YxDojd/ssQL3ulZ2keAMNYgOQPhL37lZaFHxNp9lRJJieuJrWIA+p7dHRmDniMJAIi+Xavg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.7.0.tgz",
+      "integrity": "sha512-b/7yFoRuIG7uAUgvo8L1j5JmiwbPG53sqxkyylDmZKpfG63trzJ/xBvh32O4B+DFIi7PMYLXFvyyqPmMvzttUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.6.1",
+    "vite-plugin-react-server": "^2.7.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Adopt the latest vite-plugin-react-server release (2.7.0).

mmc runs on the experimental React build, so this also exercises the experimental consumer path against the new release.

Verified locally: full `npm run build` (`vite build --app`) succeeds, all 300 static pages render and flight payloads inline cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)