### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.7.0",
+        "vite-plugin-react-server": "^2.8.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,9 +9002,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.7.0.tgz",
-      "integrity": "sha512-b/7yFoRuIG7uAUgvo8L1j5JmiwbPG53sqxkyylDmZKpfG63trzJ/xBvh32O4B+DFIi7PMYLXFvyyqPmMvzttUQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.8.0.tgz",
+      "integrity": "sha512-+hsvKBVVZxVmvqkFfBoZTQ+R1Usq61lnIntQstVdxmDFmXDLFS8mKvuxqQ004YP4y/6Kcuy/dr2Q9bxo5VUUhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.7.0",
+    "vite-plugin-react-server": "^2.8.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from 2.7.0 to 2.8.0.

2.8.0 adds opt-in server-action endpoint hardening (CSRF `allowedOrigins`, `maxBodyBytes` body cap, no stack traces in error responses) plus defense-in-depth path containment. All new behavior is opt-in and off by default, so this is a drop-in upgrade — mmc deploys the static output and does not mount the server-action endpoint, so no config changes are needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)