### PR TITLE
fix: self-host flag-icons, drop render-blocking CDN stylesheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "mmc",
       "version": "1.0.1",
+      "dependencies": {
+        "flag-icons": "^7.5.0"
+      },
       "devDependencies": {
         "@testing-library/react": "^16.1.0",
         "@testing-library/user-event": "^14.5.2",
@@ -4688,6 +4691,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/flag-icons": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/flag-icons/-/flag-icons-7.5.0.tgz",
+      "integrity": "sha512-kd+MNXviFIg5hijH766tt+3x76ele1AXlo4zDdCxIvqWZhKt4T83bOtxUOOMlTx/EcFdUMH5yvQgYlFh1EqqFg==",
+      "license": "MIT"
     },
     "node_modules/flat-cache": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -135,5 +135,8 @@
     "react": "$react",
     "react-dom": "$react-dom",
     "react-server-loader": "0.0.0-experimental-d9158919-20260615"
+  },
+  "dependencies": {
+    "flag-icons": "^7.5.0"
   }
 }

--- a/src/MmcHtml.tsx
+++ b/src/MmcHtml.tsx
@@ -44,10 +44,6 @@ export const Html: MmcHtmlType = ({
         <meta name="description" content={pageProps.description} />
         <Favicons favicons={pageProps.favicons} />
         <Css cssFiles={globalCss} />
-        <link
-          rel="stylesheet"
-          href="https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css"
-        />
       </head>
       <body>
         <Root

--- a/src/components/MakerName.tsx
+++ b/src/components/MakerName.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import * as React from "react";
 import { safeSnakecase } from "../utils/safeSnakecase.js";
 import styles from "./MakerName.module.css";
+import "./flag-icons.css";
 type MakerNameType = ThemeComponent<
   {
     level: ["makerName", "nationality", "makerId"];

--- a/src/components/flag-icons.css
+++ b/src/components/flag-icons.css
@@ -1,0 +1,7 @@
+/* Self-hosted flag-icons. Pulling the package CSS in through a project-relative
+   file (rather than a bare `flag-icons/...` import) lets vprs collect it into a
+   precedence-managed <link> in the prerendered <head>, same as globalStyles, so
+   it ships same-origin and render-blocking instead of as a remote CDN stylesheet
+   still loading at hydration. Imported only by MakerName, so the (large, all
+   flags inlined as data URIs) sheet is scoped to pages that render flags. */
+@import "flag-icons/css/flag-icons.min.css";

--- a/src/layout/Head.tsx
+++ b/src/layout/Head.tsx
@@ -29,10 +29,6 @@ export const Head: HeadType = ({
 }) => {
   return (
     <>
-      <link
-        rel="stylesheet"
-        href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/3.5.0/css/flag-icon.min.css"
-      />
       <StaticMetaTags
         title={title}
         description={description}


### PR DESCRIPTION
## Problem

GitHub Pages logged a Firefox warning: *"Layout was forced before the page was fully loaded. If stylesheets are not yet loaded, this can cause a flash of unstyled content."*

The cause was two **remote, render-blocking, non-precedence-managed** flag-icon stylesheets in `<head>`:

- `Head.tsx` → `cdnjs.../flag-icon-css@3.5.0` (the old `.flag-icon` class API — **unused**; the app only uses the `.fi` API)
- `MmcHtml.tsx` → `jsdelivr.../flag-icons@7.2.3`

Because they load from a remote origin and aren't managed by React's stylesheet precedence, they're reliably still loading when client JS forces a layout during hydration — which trips the warning and risks a flash of unstyled flags.

All the app's own CSS is already same-origin and `data-precedence="high"`, hoisted to `<head>` by React 19. Only these two remote links sat outside that.

## Change

- Remove both CDN `<link>`s (the cdnjs one was dead code).
- Add `flag-icons` as a dependency and import its CSS through a project-relative `src/components/flag-icons.css` (`@import`), imported by `MakerName`.

Routing the package CSS through a project file is what lets vprs collect it into a precedence-managed `<link>` in the prerendered `<head>` (same-origin, hashed) rather than letting it fall into the JS entry's CSS chunk. Importing it from `MakerName` scopes the (large — all flags inlined as data URIs) sheet to pages that actually render flags, instead of loading it on every page.

## Verification (against the static build)

- No `cdnjs`/`jsdelivr` links remain anywhere in `dist/static`.
- Flag pages get `<link rel="stylesheet" href="/assets/components/flag-icons-*.css" data-precedence="high">` in `<head>`.
- The homepage (no makers) no longer carries the flag CSS.
- Flags still render (`class="… fi fi-it"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)