### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.8.0",
+        "vite-plugin-react-server": "^2.9.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9002,15 +9002,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.8.0.tgz",
-      "integrity": "sha512-+hsvKBVVZxVmvqkFfBoZTQ+R1Usq61lnIntQstVdxmDFmXDLFS8mKvuxqQ004YP4y/6Kcuy/dr2Q9bxo5VUUhg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.9.0.tgz",
+      "integrity": "sha512-0Wcm35msM6pfKVD7aMwlrf2e/BuZsdsLK7C+vbYIFl4MQoJ6moqExs3+UAwWLBcci3YyH1yKoXt7x06Z5SWe2w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.10 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.11 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.8.0",
+    "vite-plugin-react-server": "^2.9.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 2.8.0 → 2.9.0.

Verified with a full `react@experimental` app build (`build-mmc`): 300 pages rendered, flight inlined, no barrel/dispatcher regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)