### PR TITLE
chore(deps): bump vite-plugin-react-server to 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.9.0",
+        "vite-plugin-react-server": "^2.10.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -9011,9 +9011,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.9.0.tgz",
-      "integrity": "sha512-0Wcm35msM6pfKVD7aMwlrf2e/BuZsdsLK7C+vbYIFl4MQoJ6moqExs3+UAwWLBcci3YyH1yKoXt7x06Z5SWe2w==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.10.0.tgz",
+      "integrity": "sha512-JmyaHaATN2g1Jgbo18XmEmh0roLSCHvDsp/STkr37SW3ohvqkCmZXpv7I6WnBUgD89FALcEREg/b7Lid1KZ2Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.9.0",
+    "vite-plugin-react-server": "^2.10.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },

--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -78,5 +78,10 @@ export const config = {
     // Flash-free first render: vprs inlines each route's flight payload into its
     // index.html at the post-SSG point, in both build modes (>= 2.6.0).
     inlineFlight: true,
+    // The single-isolate edge bundle (vprs >= 2.10.0, on by default) is for
+    // edge-runtime deploys. mmc is a static FTP-hosted site and its pinned
+    // experimental react-server-loader predates the `server.edge` export the bake
+    // needs, so opt out — keeps the build clean (no warn-and-skip).
+    edge: false,
   },
 };


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 2.9.0 → 2.10.0.

2.10.0 adds an on-by-default single-isolate edge bundle. mmc is a static FTP-hosted site (not an edge deploy), and its pinned experimental `react-server-loader` predates the `server.edge` export the bake needs, so this also sets `build.edge: false` to skip it — keeping the build output clean (no warn-and-skip).

Verified: full SSG build succeeds on experimental React (300 pages rendered, exit 0).