### PR TITLE
chore(deps): bump vprs to 2.11.0 (experimental 99e86060) + refresh dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,9 +41,9 @@
         "markdown-to-jsx": "^7.7.2",
         "npm-check-updates": "^17.1.11",
         "npm-run-all": "^4.1.5",
-        "react": "0.0.0-experimental-d9158919-20260615",
-        "react-dom": "0.0.0-experimental-d9158919-20260615",
-        "react-server-loader": "0.0.0-experimental-d9158919-20260615",
+        "react": "0.0.0-experimental-99e86060-20260623",
+        "react-dom": "0.0.0-experimental-99e86060-20260623",
+        "react-server-loader": "0.0.0-experimental-99e86060-20260623",
         "sharp": "^0.33.5",
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.1.0",
         "vite": "^6.4.1",
         "vite-css-modules": "^1.8.0",
-        "vite-plugin-react-server": "^2.9.0",
+        "vite-plugin-react-server": "^2.11.0",
         "vitest": "^3.0.4",
         "webpack-sources": "^3.2.3"
       },
@@ -7295,9 +7295,9 @@
       }
     },
     "node_modules/react": {
-      "version": "0.0.0-experimental-d9158919-20260615",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-d9158919-20260615.tgz",
-      "integrity": "sha512-XB3kpHdzfFQs/kj+rernMVQC9Nrt7ToSViho4yLLCp9WAKrpiTfDGPNA5ozQ7PDMw7npVetGXuX3MWKbwc40uw==",
+      "version": "0.0.0-experimental-99e86060-20260623",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-99e86060-20260623.tgz",
+      "integrity": "sha512-SMJh+79N2JchHBBat39YF1e2pW0+izNko1ZbURsHHZT5SkIYGSFTfCdl/VwCdDHBQc6YMOmp/0P+IVFhFbbXEA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7305,16 +7305,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "0.0.0-experimental-d9158919-20260615",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-d9158919-20260615.tgz",
-      "integrity": "sha512-sHxXG/LmtS/tvckGrllFpPqdfIb7h3gcXzyq+PhqAeapPZfksILaxNUueqOh7Tuf5T1Qd//7LUTz86ZLNHQdmQ==",
+      "version": "0.0.0-experimental-99e86060-20260623",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-99e86060-20260623.tgz",
+      "integrity": "sha512-ocfoSLwjgdBRe5HCpLLaFJS3jA4HWzNA8oH0bVAyOPhDhqdY/N2fAzow88anpE6W1Mro7mWswGoyZUbjxulPfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "scheduler": "0.0.0-experimental-d9158919-20260615"
+        "scheduler": "0.0.0-experimental-99e86060-20260623"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-d9158919-20260615"
+        "react": "0.0.0-experimental-99e86060-20260623"
       }
     },
     "node_modules/react-is": {
@@ -7336,9 +7336,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "0.0.0-experimental-d9158919-20260615",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-d9158919-20260615.tgz",
-      "integrity": "sha512-E6YwVX2+bMp0TxMmy8B297MQzuUaATkP/vAiSdz9rjBjrChzAS4Yq7lXgahxlQcmMM1pR4IODnpNIArbIsvqAA==",
+      "version": "0.0.0-experimental-99e86060-20260623",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-99e86060-20260623.tgz",
+      "integrity": "sha512-IWpdByMIB5YCAeeMyhtCEonlT2gj4JqRltulmFwCoQ7hMjM9D5EIoiT/hfgYlD+iSF9koHQ4Cz5ta8ibVPdlMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7350,8 +7350,8 @@
         "node": ">=22.0.0"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-d9158919-20260615",
-        "react-dom": "0.0.0-experimental-d9158919-20260615"
+        "react": "0.0.0-experimental-99e86060-20260623",
+        "react-dom": "0.0.0-experimental-99e86060-20260623"
       }
     },
     "node_modules/react-server-loader/node_modules/source-map": {
@@ -7703,9 +7703,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.0.0-experimental-d9158919-20260615",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-d9158919-20260615.tgz",
-      "integrity": "sha512-4Ku4WFsdKS/v8Afd0IOCoxZsnwU9GiOWHKqlmquPNAtpms3cGj3Yhz7Evamsgn1ztKZw0uSYZ7a5iPcPtiUeUA==",
+      "version": "0.0.0-experimental-99e86060-20260623",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-99e86060-20260623.tgz",
+      "integrity": "sha512-Ju3qqIEG8bfPm1GZT4z/WXPyrq9ji1y3Ngrfa0zuj0vLrI7fRd6tAVh6jA2ctRqUcIvpJzqeGU5DELz8RvxL+w==",
       "dev": true,
       "license": "MIT"
     },
@@ -9011,15 +9011,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.9.0.tgz",
-      "integrity": "sha512-0Wcm35msM6pfKVD7aMwlrf2e/BuZsdsLK7C+vbYIFl4MQoJ6moqExs3+UAwWLBcci3YyH1yKoXt7x06Z5SWe2w==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-2.11.0.tgz",
+      "integrity": "sha512-RpCmmTuOEu52oazY1iny+mXSWfSBPYW6yAWKH2IqQiM5AMvryvG9KQeEFrhPqyCr/o8c4rzCh16co+ZNOEhCDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.11 || >=0.0.0-0 <0.0.1",
+        "react-server-loader": "^19.2.12 || >=0.0.0-0 <0.0.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },
@@ -9029,7 +9029,7 @@
       "peerDependencies": {
         "react": "^19.2.7 || >=0.0.0-0 <0.0.1",
         "react-dom": "^19.2.7 || >=0.0.0-0 <0.0.1",
-        "vite": "*"
+        "vite": "^6.3.5 || ^7 || ^8"
       },
       "peerDependenciesMeta": {
         "react": {

--- a/package.json
+++ b/package.json
@@ -114,9 +114,9 @@
     "markdown-to-jsx": "^7.7.2",
     "npm-check-updates": "^17.1.11",
     "npm-run-all": "^4.1.5",
-    "react": "0.0.0-experimental-d9158919-20260615",
-    "react-dom": "0.0.0-experimental-d9158919-20260615",
-    "react-server-loader": "0.0.0-experimental-d9158919-20260615",
+    "react": "0.0.0-experimental-99e86060-20260623",
+    "react-dom": "0.0.0-experimental-99e86060-20260623",
+    "react-server-loader": "0.0.0-experimental-99e86060-20260623",
     "sharp": "^0.33.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.21.0",
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.1.0",
     "vite": "^6.4.1",
     "vite-css-modules": "^1.8.0",
-    "vite-plugin-react-server": "^2.9.0",
+    "vite-plugin-react-server": "^2.11.0",
     "vitest": "^3.0.4",
     "webpack-sources": "^3.2.3"
   },
@@ -134,7 +134,7 @@
   "overrides": {
     "react": "$react",
     "react-dom": "$react-dom",
-    "react-server-loader": "0.0.0-experimental-d9158919-20260615"
+    "react-server-loader": "0.0.0-experimental-99e86060-20260623"
   },
   "dependencies": {
     "flag-icons": "^7.5.0"


### PR DESCRIPTION
Bumps vite-plugin-react-server `^2.9.0` → `^2.11.0` (adds Vite 6/7/8 support) and moves the experimental React trio (`react`, `react-dom`, `react-server-loader`, including the `react-server-loader` override) from the `d9158919` snapshot to `99e86060`, so the vendored RSC transport, directive engine, and React runtime all come from the same build. Mixing experimental snapshots crashes on internals skew, so the three move together.

Supersedes #126 (the 2.10.0 bump).

**Verified:** `vite build --app` under `--conditions react-server` renders all 300 pages and bakes the single-isolate edge bundle, clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MwAnpKZrUCY2FXPGgUyhu