### PR TITLE
fix(startup): adapt to sharp 0.35 type exports

### DIFF
--- a/startup/resize/toPlaceholderBase64.mts
+++ b/startup/resize/toPlaceholderBase64.mts
@@ -1,4 +1,4 @@
-import sharp from "sharp";
+import type { Sharp } from "sharp";
 import { aspectRatio } from "./faviconRatio.mjs";
 
 /**
@@ -6,7 +6,7 @@ import { aspectRatio } from "./faviconRatio.mjs";
  */
 export async function toPlaceholderBase64(
   job: ResizeJob,
-  instance: sharp.Sharp
+  instance: Sharp
 ) {
   if (!job.userInfo.placeholder) return;
   try {


### PR DESCRIPTION
Fixes the build break introduced by the sharp 0.33 → 0.35 bump in #128. For a `0.x` dependency a minor bump is breaking: sharp 0.34+ ships an ESM type entry (`dist/index.d.mts`) that `.mts` files resolve, exporting `Sharp` as a named interface instead of merging it into the default export's namespace.

`startup/resize/toPlaceholderBase64.mts` used `sharp.Sharp`, which failed with `Cannot find namespace 'sharp'` and cascaded into an implicit-`any` on the catch param. Now imports the type by name.

**Verified the full CI sequence locally:** `tsc --project tsconfig.node.json` (the failing step) + `startup:gh` (sharp 0.35 runtime image processing) + `build:gh` (300 pages + edge bundle), all green.
