### PR TITLE
fix(types): narrow $theme page props to the home-data branch

### DIFF
--- a/src/app/$theme/page.tsx
+++ b/src/app/$theme/page.tsx
@@ -7,6 +7,8 @@ import { type RouteType } from "./props.js";
 export const Page: ThemePageComponent<RouteType | "/"> = (props) => {
   if (!props) {
     throw new Error("props is undefined");
+  } else if(!("images" in props) || !props.images) {
+    throw new Error("props.images is undefined. It's likely that the props function didn't get the correct route.");
   }
   const {
     images: { logo, logo_special, illustration },


### PR DESCRIPTION
Fixes the type errors on `main` after #131.

The shared `$theme` loader returns a union — full home data at the theme root, `{ pathInfo }` for the descendants its layout wraps — so `$theme/page.tsx`'s destructure (`images`, `info`, `adjacent`, …) didn't type-check against the minimal branch. This narrowing guard was written but still uncommitted when #131 was squash-merged, so it didn't ride along.

Guard on `"images" in props` (throwing if absent): it asserts the loader handed this page the right route and narrows the union to the full-home shape for the destructure. `tsc --project tsconfig.node.json` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS