### PR TITLE
fix(deploy): GitHub Pages bootstrap module 404 (base URL for SSG env)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
     "build:app": "vite build --app",
     "build:prod": "npm run env:prod -- vite build --app",
-    "build:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true NODE_OPTIONS='--conditions react-server' vite build --app",
+    "build:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' VITE_PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' VITE_BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true NODE_OPTIONS='--conditions react-server' vite build --app",
     "build:preview": "npm run env:preview -- vite build --app",
     "build:dev": "vite build --app",
     "debug-build": "NODE_ENV=development npm run build",
@@ -47,9 +47,9 @@
     "preview:prod": "npm run startup:prod && npm run build:prod && vite preview",
     "preview:gh": "npm run startup:gh && npm run build:gh && npm run env:gh -- vite preview",
     "oopsie-wsl": "find . -type f -name \"*:Zone.Identifier\" -exec rm {} \\;",
-    "env:prod": "PUBLIC_ORIGIN='https://mmcelebration.com' BASE_URL='/' NODE_ENV=production",
-    "env:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true",
-    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/' NODE_ENV=production",
+    "env:prod": "PUBLIC_ORIGIN='https://mmcelebration.com' BASE_URL='/' VITE_PUBLIC_ORIGIN='https://mmcelebration.com' VITE_BASE_URL='/' NODE_ENV=production",
+    "env:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' VITE_PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' VITE_BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true",
+    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/' VITE_PUBLIC_ORIGIN='http://localhost:4173' VITE_BASE_URL='/' NODE_ENV=production",
     "env:dev": "NODE_ENV=development"
   },
   "engines": {


### PR DESCRIPTION
Production hotfix for the broken GitHub Pages deploy (`nicobrinkkemper.github.io/mmc/`).

**Symptom:** `GET /index-f3chqi.js` → 404 → served as HTML → `NS_ERROR_CORRUPTED_CONTENT`; the page never hydrates. The client bootstrap `<script>` loaded from the site root instead of `/mmc/`.

**Cause:** vprs's isomorphic env-URL helpers (which build the bootstrap `<script src>`) read `process.env.VITE_BASE_URL` / `VITE_PUBLIC_ORIGIN` on the Node/SSG side. Our scripts set only the unprefixed `BASE_URL` / `PUBLIC_ORIGIN`, so Vite's own base (assets, CSS) and the favicon helper resolved `/mmc/` correctly, but vprs's bootstrap fell back to `/`.

**Fix:** mirror the `VITE_`-prefixed names in `build:gh` and `env:{prod,gh,preview}`. Verified `build:gh` now emits `<script id="_R_" src="/mmc/index-*.js">`.

Follow-up (vprs-side, not this PR): vprs's `env.node` should read `BASE_URL`/`PUBLIC_ORIGIN` too (not just the `VITE_` prefix), so consumers don't need the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS