### PR TITLE
fix(client): stop double-applying the deploy base on client navigation

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -8,7 +8,6 @@ import React, {
 import { createRoot, hydrateRoot } from "react-dom/client";
 import { useRscHmr } from "virtual:react-server/hmr";
 import { createReactFetcher } from "vite-plugin-react-server/utils";
-import { baseURL } from "./config/env.js";
 import { ErrorMessage } from "./ErrorMessage.js";
 import "./globalStyles.css";
 import { useEventListener } from "./hooks/useEventListener.js";
@@ -53,11 +52,14 @@ const Shell: React.FC<{
   useEventListener(
     "popstate",
     (e) => {
-      const newTo = baseURL(
+      // window.location.pathname and Clickable's pushState `to` are already
+      // base-absolute (e.g. "/mmc/5ymm/"). Do NOT re-apply baseURL() — it would
+      // prepend the deploy base a second time ("/mmc/mmc/5ymm/") and 404 the RSC
+      // fetch. createReactFetcher handles the base-absolute path directly.
+      const newTo =
         !(e instanceof PopStateEvent) || typeof e.state?.to !== "string"
           ? window.location.pathname
-          : e.state.to
-      );
+          : e.state.to;
       console.log("navigating to", newTo);
       return refetch(newTo);
     },


### PR DESCRIPTION
Fixes the broken client-side navigation on the `/mmc/` (GitHub Pages / staging) deploy — the last piece of the base-URL breakage.

**Symptom:** clicking a link navigated to `/mmc/mmc/<route>/` and fetched `/mmc/mmc/<route>/index.rsc` (404); react-server-dom-esm then threw `enqueueModel is not a function` decoding the 404 HTML. First paint was fine; only navigation broke (static/no-JS nav worked, which masked it).

**Cause:** the `popstate` handler wrapped the nav target in `baseURL()`, but both `window.location.pathname` and Clickable's pushState `to` are already **base-absolute** (`/mmc/5ymm/`). mmc's `baseURL()` (which does not de-dupe) prepended `/mmc/` a second time. The initial mount already passes the pathname unwrapped, which is why first paint worked.

**Fix:** pass the base-absolute path straight through — `createReactFetcher` (via vprs's `createBaseURL`) resolves it without re-adding the base.

Not a vprs bug: vprs's URL helpers de-dupe correctly; this was mmc's hand-rolled nav. Real prod (base `/`) was unaffected.

Follow-up (separate): replace this hand-rolled `client.tsx` nav with vprs's `startClient` — deletes the boilerplate and is the better showcase for the main example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS