### PR TITLE
fix(client): stop double-prefixing the base on favicon URLs

### DIFF
--- a/src/layout/Favicons.tsx
+++ b/src/layout/Favicons.tsx
@@ -1,39 +1,30 @@
 import type { ComponentProps } from "react";
 import * as React from "react";
-import { absoluteURL } from "../config/env.js";
 
 export type FaviconsType = ThemeComponent<{
   favicons: true;
 }>;
 export type FaviconProps<T> = T & ComponentProps<FaviconsType>;
 
+// `favicons.*` are already fully resolved URLs — getStaticData runs each through
+// absoluteURL. Render them as-is. Re-applying absoluteURL here double-prefixes
+// the deploy base on the client, where the decoded flight value is a base-
+// absolute path: "/mmc/8mmc/favicon.ico" -> "/mmc/mmc/8mmc/favicon.ico" (404).
 export const Favicons: FaviconsType = ({ favicons }) => {
   if (!favicons) return null;
   return (
     <>
       {favicons.favicon ? (
-        <link rel="icon" href={absoluteURL(favicons.favicon)} />
+        <link rel="icon" href={favicons.favicon} />
       ) : null}
       {favicons.favicon_512x512 ? (
-        <link
-          rel="icon"
-          sizes="512x512"
-          href={absoluteURL(favicons.favicon_512x512)}
-        />
+        <link rel="icon" sizes="512x512" href={favicons.favicon_512x512} />
       ) : null}
       {favicons.favicon_192x192 ? (
-        <link
-          rel="icon"
-          sizes="192x192"
-          href={absoluteURL(favicons.favicon_192x192)}
-        />
+        <link rel="icon" sizes="192x192" href={favicons.favicon_192x192} />
       ) : null}
       {favicons.favicon_64x64 ? (
-        <link
-          rel="icon"
-          sizes="64x64"
-          href={absoluteURL(favicons.favicon_64x64)}
-        />
+        <link rel="icon" sizes="64x64" href={favicons.favicon_64x64} />
       ) : null}
     </>
   );


### PR DESCRIPTION
Fixes the remaining base-double on the `/mmc/` (GitHub Pages / staging) deploy — favicons 404'd at `/mmc/mmc/<theme>/favicon-*.ico`.

**Cause:** `absoluteURL` applied twice. `getStaticData` already builds `favicons.* = absoluteURL(...)`, then `Favicons.tsx` applied `absoluteURL()` again. On the server the value is a full `https://` URL so `isAbsolute()` short-circuits the second call; on the client the decoded flight value is a base-absolute *path*, so the second `absoluteURL` re-prefixes `/mmc/` → `/mmc/mmc/…`.

**Fix:** render the already-resolved favicon URLs directly. SSG output verified unchanged (single `/mmc/`, zero `/mmc/mmc`). Real prod (base `/`) was unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS