### PR TITLE
refactor(client): adopt vprs startClient, delete hand-rolled nav boilerplate

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -1,133 +1,27 @@
 "use client";
-import React, {
-  useCallback,
-  useState,
-  useTransition,
-  type ReactNode,
-} from "react";
-import { createRoot, hydrateRoot } from "react-dom/client";
-import { useRscHmr } from "virtual:react-server/hmr";
-import { createReactFetcher } from "vite-plugin-react-server/utils";
-import { baseURL } from "./config/env.js";
+import * as React from "react";
+import { startClient } from "vite-plugin-react-server/router/client";
 import { ErrorMessage } from "./ErrorMessage.js";
 import "./globalStyles.css";
-import { useEventListener } from "./hooks/useEventListener.js";
+
 /**
- * Client-side React Server Components implementation
+ * mmc client entry.
  *
- * This module handles:
- * 1. Initial hydration of server-rendered content
- * 2. Client-side navigation using RSC
- * 3. State management for RSC data
- * 4. Stream updates when files change
+ * vprs's `startClient` is the supplied client entry: it assembles the headless
+ * router, initial-flight hydration (consuming the inlined payload on first
+ * paint), client-side navigation, and RSC HMR. So the whole hand-rolled Shell /
+ * popstate handler / refetch / hydrateRoot boilerplate collapses to one call —
+ * the ErrorBoundary is injected through `wrap`.
+ *
+ * Navigation still flows through the existing <ClientClickable> links: they
+ * pushState + dispatch popstate, which the router listens for. mmc reads route
+ * params from the loader (props), not useParams, so no `patterns` are needed.
  */
-
-/**
- * Main application shell component
- * Handles navigation and RSC data updates
- */
-const Shell: React.FC<{
-  initialNode: ReactNode;
-}> = ({ initialNode }) => {
-  const [, startTransition] = useTransition();
-  const [content, setContent] = useState<ReactNode>(initialNode);
-
-  const refetch = useCallback((to: string, scrollToTop = true) => {
-    if (scrollToTop && "scrollTo" in window) window.scrollTo(0, 0);
-    // Resolve the next route's payload to a ReactNode *before* swapping it in,
-    // so the render stays synchronous (no Suspense boundary, no `use()`) and
-    // never flashes an empty tree — the same decode-then-render path as the
-    // initial mount below.
-    Promise.resolve(
-      createReactFetcher({
-        url: to,
-        moduleBaseURL: import.meta.env.BASE_URL,
-        publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-      })
-    ).then((node) => {
-      startTransition(() => setContent(node as ReactNode));
-    });
-  }, []);
-
-  // Handle browser navigation
-  useEventListener(
-    "popstate",
-    (e) => {
-      const newTo = baseURL(
-        !(e instanceof PopStateEvent) || typeof e.state?.to !== "string"
-          ? window.location.pathname
-          : e.state.to
-      );
-      console.log("navigating to", newTo);
-      return refetch(newTo);
-    },
-    window
-  );
-
-  // RSC HMR: refetch the stream when server components or CSS modules change.
-  // scrollToTop=false preserves the user's scroll position across edits.
-  useRscHmr((url) => refetch(url, false));
-
-  return <ErrorBoundary>{content}</ErrorBoundary>;
-};
-// Initialize the app
-const rootElement = document.getElementById("root");
-if (!rootElement) throw new Error("Root element not found");
-
-// Fully resolve the initial payload to a ReactNode *before* mounting, then
-// render that node directly — a synchronous first render with no Suspense
-// boundary, so hydrateRoot matches the prerendered HTML exactly. (Wrapping the
-// root in a <Suspense> the server never rendered, or `use()`-ing a pending
-// thenable, mismatches the prerender → React #418.) With the build's inlined
-// flight payload, createReactFetcher decodes in place with no network
-// round-trip; without it (e.g. dev) it falls back to fetching index.rsc.
-Promise.resolve(
-  createReactFetcher({
-    url: window.location.pathname,
-    moduleBaseURL: import.meta.env.BASE_URL,
-    publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-  })
-).then(
-  (initialNode) => {
-    // Hydrate the prerendered HTML when present; fall back to a fresh client
-    // render when #root is empty (e.g. dev without prerender).
-    if (rootElement.hasChildNodes()) {
-      hydrateRoot(rootElement, <Shell initialNode={initialNode as ReactNode} />);
-    } else {
-      createRoot(rootElement).render(
-        <Shell initialNode={initialNode as ReactNode} />
-      );
-    }
-  },
-  (err) => {
-    // Stay on the prerendered static HTML rather than mounting a broken tree;
-    // links fall back to normal full-page navigation.
-    console.error("[mmc] initial RSC payload failed to load; staying static", err);
-  }
-);
-
-/**
- * Error boundary
- */
-
-export class ErrorBoundary extends React.Component {
-  public state: {
-    hasError: boolean;
-    error: Error | null;
-  } = {
-    hasError: false,
-    error: null,
-  };
-  public props: {
-    children: React.ReactNode;
-  } = {
-    children: null,
-  };
-  constructor(props: { children: React.ReactNode }) {
-    super(props);
-    this.state = { hasError: false, error: null };
-    this.props = props;
-  }
+class ErrorBoundary extends React.Component<
+  { children: React.ReactNode },
+  { hasError: boolean; error: Error | null }
+> {
+  state = { hasError: false, error: null as Error | null };
 
   static getDerivedStateFromError(error: Error) {
     return { hasError: true, error };
@@ -135,28 +29,23 @@ export class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      if (this.state.error) {
-        return (
-          <ErrorMessage
-            error={{
-              message: this.state.error.message,
-              stack: this.state.error.stack,
-            }}
-          />
-        );
-      }
-      return <div>Error</div>;
+      return this.state.error ? (
+        <ErrorMessage
+          error={{
+            message: this.state.error.message,
+            stack: this.state.error.stack,
+          }}
+        />
+      ) : (
+        <div>Error</div>
+      );
     }
     return this.props.children;
   }
 }
 
-if (import.meta.hot) {
-  import.meta.hot.accept((newModule) => {
-    console.log("newModule", newModule);
-    if (newModule) {
-      // newModule is undefined when SyntaxError happened
-      console.log("updated: count is now ", newModule["count"]);
-    }
-  });
-}
+startClient({
+  moduleBaseURL: import.meta.env.BASE_URL,
+  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+  wrap: (node: React.ReactNode) => <ErrorBoundary>{node}</ErrorBoundary>,
+});

--- a/src/components/Clickable.client.tsx
+++ b/src/components/Clickable.client.tsx
@@ -15,14 +15,16 @@ export const ClientClickable: React.FC<{
         (e.currentTarget &&
           "target" in e.currentTarget &&
           e.currentTarget.target === "_blank");
-      if (!isBlank) {
-        e.preventDefault();
-      }
-      // Use pathname, not full href - createReactFetcher expects a path like "/10mmc/"
+      if (isBlank) return;
+      e.preventDefault();
+      // Scroll to top on forward navigation (a link click). Doing it here — not
+      // on every popstate — means browser back/forward keeps its scroll offset.
+      if ("scrollTo" in window) window.scrollTo(0, 0);
+      // Use pathname, not full href — the router expects a path like "/10mmc/".
       const newTo =
         e.currentTarget && "href" in e.currentTarget
           ? new URL(e.currentTarget.href).pathname
-          : href || '/';
+          : href || "/";
       const newState = { to: newTo };
       window.history.pushState(newState, "", newTo);
       window.dispatchEvent(new PopStateEvent("popstate", { state: newState }));


### PR DESCRIPTION
The showcase follow-up: mmc is the main vprs example, so its client entry should use vprs's supplied `startClient` rather than hand-rolling navigation.

**What changes:** `client.tsx` 162 → 51 lines. The Shell component, popstate handler, `refetch`, direct `createReactFetcher`, and `hydrateRoot`/`createRoot` boilerplate all collapse into one `startClient({ wrap })` call. `startClient` assembles the router, initial-flight hydration (consuming the inlined payload on first paint), client navigation, and RSC HMR.

- ErrorBoundary injected via `wrap`.
- Existing `<ClientClickable>` links still drive nav (pushState + popstate, which the router listens for).
- No `patterns` needed — mmc reads route params from the loader (props), not `useParams`.
- Scroll-to-top folded into `ClientClickable` (forward nav only, so back/forward keeps scroll — an improvement over the old scroll-on-every-popstate).

**Relationship to other PRs:** supersedes #134 (the nav-double-base fix — that buggy `baseURL()` wrapper lived in the now-deleted handler; `startClient` routes through vprs's de-duping `createBaseURL`). Independent of #135 (favicons) and #132 (types).

**Verified:** build (both env legs) — 300 pages, full skeleton, single `/mmc/` bootstrap + nav hrefs, degrade-guard silent, typecheck clean. **Client-runtime nav needs a browser check** (hydration + navigation are runtime) — please verify on a `/mmc/` preview/deploy before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS