### PR TITLE
fix(env): de-dupe the deploy base in baseURL()

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -26,12 +26,22 @@ const origin =
 const isAbsolute = (path: string): boolean =>
   /^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//");
 
-/** Prefix a path with the deploy base (`/mmc/foo`); absolute URLs pass through. */
-export const baseURL = (path: string): string =>
-  isAbsolute(path)
-    ? path
-    : new URL(path.replace(/^\/+/, ""), `http://_/${base.replace(/^\/+/, "")}`)
-        .pathname;
+/**
+ * Prefix a path with the deploy base (`/mmc/foo`); absolute URLs pass through.
+ *
+ * De-dupes: a path that ALREADY carries the base is returned unchanged instead
+ * of double-prefixed. Vite asset URLs (e.g. `images.favicon.src`) already
+ * include the deploy base, so without this `absoluteURL(images.favicon.src)`
+ * produced `/mmc/mmc/…/favicon.ico`.
+ */
+export const baseURL = (path: string): string => {
+  if (isAbsolute(path)) return path;
+  const b = base.replace(/\/+$/, ""); // "/mmc" (or "" for root base "/")
+  const p = path.startsWith("/") ? path : `/${path}`;
+  if (b && (p === b || p.startsWith(`${b}/`))) return p;
+  return new URL(p.replace(/^\/+/, ""), `http://_/${base.replace(/^\/+/, "")}`)
+    .pathname;
+};
 
 /** `baseURL`, resolved absolute against the public origin. */
 export const absoluteURL = (path: string): string =>


### PR DESCRIPTION
Completes the favicon base-double fix (#135 was only half of it).

**Cause:** mmc's `baseURL()` unconditionally prepends the deploy base. `getStaticData` builds `favicons.* = absoluteURL(images.favicon.src)`, and `images.favicon.src` is a Vite asset URL that *already* includes the base — so `baseURL()` prepended `/mmc/` a second time → `/mmc/mmc/<theme>/favicon.ico` (404 on the `/mmc/` deploy). #135 stopped the client-side re-apply in `Favicons.tsx`, but the source double was still in the data layer.

**Fix:** `baseURL()` returns the path unchanged when it already starts with the base (matched as a whole path segment). Base-relative inputs still get the base once; root base `/` is a no-op. Same de-dupe vprs's own `createBaseURL` does.

**Verified** with a `/mmc/`-base + localhost-origin build: favicon is now single `…/mmc/<theme>/favicon.ico` in both the HTML head and the flight, zero `/mmc/mmc`, nav hrefs single, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS