### PR TITLE
fix(404): build the image meta from logo.src, not the image object

### DIFF
--- a/src/app/404/props.ts
+++ b/src/app/404/props.ts
@@ -1,3 +1,4 @@
+import { absoluteURL } from "../../config/env.js";
 import { siteName } from "../../config/themeConfig.js";
 import { createProps } from "../../data/createProps.js";
 
@@ -26,6 +27,6 @@ export const props = createProps(
   ({ info: { writtenOut }, images: { logo } }) => ({
     description: `${writtenOut}! | ${siteName}`,
     title: `${writtenOut} | 404`,
-    image: (import.meta.env.BASE_URL ?? "/") + logo,
+    image: absoluteURL(logo.src),
   })
 );


### PR DESCRIPTION
The 404's `image` meta shipped as `content="/mmc/[object Object]"`.

**Cause:** `src/app/404/props.ts` set `image: (import.meta.env.BASE_URL ?? "/") + logo`, but `logo` (from `images: { logo }`) is the image *object*, not a string — so template concatenation stringified it to `[object Object]`, and the hand-rolled base prefix skipped the origin.

**Fix:** `image: absoluteURL(logo.src)` — the same path the themes use (`absoluteURL(images.favicon.src)`): resolves the src, attaches the origin, and de-dupes the base (via #137).

Verified on a `/mmc/` build: no `[object Object]`, image meta is now `…/mmc/<theme>/logo-200.webp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS