### PR TITLE
chore(css): raise inlineThreshold to inline global + small CSS (FOUC)

### DIFF
--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -64,7 +64,7 @@ export const config = {
   }),
   serverEntry: "src/server.tsx",
   css: {
-    inlineThreshold: 1000,
+    inlineThreshold: 4096,
   },
   build: {
     // Flash-free first render: vprs inlines each route's flight payload into its


### PR DESCRIPTION
Addresses the forced-layout / flash-of-unstyled-content warning on load.

`globalStyles` (~2.5KB) sat just above the old `inlineThreshold: 1000`, so it shipped as an external `<link>` — exactly the kind of render-blocking-yet-async sheet that triggers the FOUC warning. Raising the threshold to **4096** inlines it (and the other small per-route sheets) as `<style>`, so first paint waits on nothing external.

**Verified:**
- Home page: 0 stylesheet `<link>`s, globalStyles inlined (`box-sizing:border-box` present in a `<style>`).
- A flag level page: `flag-icons` (~419KB) still a `<link>`; HTML ~103KB, not ~420KB — the big sheet stays external.

Confirms vprs already respects the threshold for globalCss, so no plugin option was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016J2gLpQiWUGZ28trAtPAVS