### PR TITLE
chore(deps): bump vite-plugin-react-server to 3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.1.0",
+        "vite-plugin-react-server": "^3.1.1",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.0.tgz",
-      "integrity": "sha512-6dAt4nM9/fcgA5he6H6WBa5t8L4pB59bM2Q1uOfMXt3wKwDN48zPTP+f91Gb3Gey6JFwUY/3HFtmPI/CGRACVQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.1.tgz",
+      "integrity": "sha512-02neWKDmy5GiZA1KFZhm2nHa+AbbIbv+3Mh/tydVNWLincBXkhvHW2DVPU2wXiSA9QWtlyUMqglaRSPGvEHZqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.1.0",
+    "vite-plugin-react-server": "^3.1.1",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 3.1.0 → 3.1.1.

The headline fix restores client hydration in dev. `startClient`'s lazy `import("react-dom/client")` destructured `createRoot`/`hydrateRoot` off the namespace top level; Vite's dev server serves the raw CJS module, so a dynamic import lands the exports on `.default`, and both `dev:ssr` and `dev:rsc` threw `createRoot is not a function` on first mount (`preview`/build were unaffected). 3.1.1 reads the top level first and falls back to `.default`.

Also in 3.1.1 (all router/client internals, no API change): client flightCache LRU bound, `orderPatterns` content-keyed cache, resolved loader `logger` typed optional.

Verified against this repo: full build (300 pages, edge bundle) and clean `dev:ssr` hydration on the real 3.1.1 install.