### PR TITLE
chore(deps): bump vite-plugin-react-server to 3.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.1.1",
+        "vite-plugin-react-server": "^3.1.2",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.1.tgz",
-      "integrity": "sha512-02neWKDmy5GiZA1KFZhm2nHa+AbbIbv+3Mh/tydVNWLincBXkhvHW2DVPU2wXiSA9QWtlyUMqglaRSPGvEHZqA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.2.tgz",
+      "integrity": "sha512-2icYBv0sTbQ1IiUQEo0tJ23qYajTZBl38DpWkLmGz8s36muvhMf4Avy2Dckf3ncZAHpggnMotcvqMMaOFHnuyQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.1.1",
+    "vite-plugin-react-server": "^3.1.2",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` 3.1.1 → 3.1.2 for the `startClient` RSC HMR fix.

On 3.1.1, a server-component edit fired the HMR event but the view didn't update until a manual reload — the HMR handler refetched through the flight cache, which holds static-route flights indefinitely, so it got the stale flight. 3.1.2 busts the cache on HMR.

Verified against this repo on the real published 3.1.2: editing a server component (home `page.tsx`) hot-updates the view with no full page reload, no page errors.