### PR TITLE
fix(client): wait for a parsed document before reading the flight payload

### DIFF
--- a/src/client.tsx
+++ b/src/client.tsx
@@ -44,8 +44,31 @@ class ErrorBoundary extends React.Component<
   }
 }
 
-startClient({
-  moduleBaseURL: import.meta.env.BASE_URL,
-  publicOrigin: import.meta.env.PUBLIC_ORIGIN,
-  wrap: (node: React.ReactNode) => <ErrorBoundary>{node}</ErrorBoundary>,
-});
+const boot = () =>
+  startClient({
+    moduleBaseURL: import.meta.env.BASE_URL,
+    publicOrigin: import.meta.env.PUBLIC_ORIGIN,
+    wrap: (node: React.ReactNode) => <ErrorBoundary>{node}</ErrorBoundary>,
+  });
+
+/**
+ * WORKAROUND, pending a fix in vite-plugin-react-server.
+ *
+ * `startClient` reads the initial flight payload out of the inlined
+ * `<script id="vprs-flight">` element as soon as it runs. This entry is emitted
+ * as `<script type="module" async>`, so its execution is not ordered against the
+ * HTML parser: once the module is in cache (a repeat visit, or navigating away
+ * from a still-loading page) it can run while the parser is still streaming text
+ * into that script element. It then decodes a TRUNCATED payload — measured at
+ * 1319 of 22088 chars — React reaches the end of an incomplete flight stream and
+ * throws #412 ("Connection closed"), and the page stays un-hydrated until a
+ * reload: no client-side navigation at all.
+ *
+ * A fully parsed document is what makes the payload whole, so wait for one.
+ * Remove this once the plugin defers the read itself.
+ */
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", boot, { once: true });
+} else {
+  boot();
+}


### PR DESCRIPTION
## The bug

Clicking a link while a page is still loading could leave the site permanently un-hydrated: content renders, but there is no client-side navigation until a manual reload. The console shows:

```
[vprs] hydrateOrRender: initial payload failed; staying static
Error: Minified React error #412
```

React 412 decodes to **"Connection closed."**

## Root cause

`startClient` reads the initial flight payload out of the inlined `<script id="vprs-flight">` element the moment it runs. This entry is emitted as `<script type="module" async>`, so its execution is **not ordered against the HTML parser**. When the module is already in cache, it can run while the parser is still streaming text into that script element — and it then decodes a **truncated** payload.

Measured on production by patching `document.getElementById` before any page script:

| scenario | payload read | result |
|---|---|---|
| direct load | `readyState: "interactive"` — **22088** of 22088 chars | hydrates |
| navigate mid-load | `readyState: "loading"` — **1319** of 22088 chars | React #412, stays static |

React reaches the end of an incomplete flight stream, throws, and `hydrateOrRender` catches it and degrades to static — which is why this failed silently rather than blanking the page.

The trigger is really **warm module cache + slow HTML**, not the click as such. Clicking mid-load just reliably manufactures that state: the abandoned first document warms the JS, then the destination HTML arrives over a slow pipe. A repeat visitor on a poor connection can hit this without clicking anything.

The assets are not corrupt (full transfer/decoded sizes), the destination page hydrates fine on a direct load, and a reload recovers — same bytes, different timing. It is purely a read-time race.

## The change

Wait for a parsed document before mounting: a complete document is precisely the condition that makes the inline payload whole.

## Verification

Playwright + CDP network throttling (~1.5 Mbps), reproducing the exact failing scenario — load `/`, click a `/levels` link 400ms in — against a local build of `dist/static`:

- **before:** `lenAtRead` 1319 / 22088, React #412, `hydrated: false`
- **after:** full payload read, no truncation, `hydrated: true` — 3 runs, 3 passes

## Follow-up

This is a workaround in the consumer, and it is labelled as one in the source. The real fix belongs in vite-plugin-react-server: it should not read the inline payload while `document.readyState === "loading"` (or, sturdier, emit the payload as chunked pushes with an explicit close, so a consumer that attaches early still receives every row). This can be reverted once the plugin defers the read itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)