### PR TITLE
chore(deps): vite-plugin-react-server 3.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.1.4",
+        "vite-plugin-react-server": "^3.1.5",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.4.tgz",
-      "integrity": "sha512-UrpOcfxp12acM6XrMoeR0AvZ3goWrSENQkDrs7aX+JeP+5zlpieQ0Wzx17+6teUlTvH+WRd4U+IqH53u+qUr3Q==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.5.tgz",
+      "integrity": "sha512-wK+CHFx5t4HlyxrlU2PsOZLv8T6OgwtlZ5dGk6odY3zAGtLeTzPc7W0gIU6+cmNFl223k0xlfx2EKpkqy+qjzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.1.4",
+    "vite-plugin-react-server": "^3.1.5",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Supersedes #145, which worked around this in the app. With 3.1.5 the fix lives in the plugin, so no consumer-side change is needed — closing #145 unmerged keeps the throwaway diff out of this repo's history.

## What 3.1.5 fixes

`createReactFetcher` read the inlined flight payload — the text of the `<script id="vprs-flight">` element — the moment it ran. The client entry is an `async` module, so its execution is not ordered against the HTML parser: when the entry is already cached (a repeat visit, or navigating away from a still-loading page) it could run **while the parser was still streaming text into that element**, decode a truncated payload, and leave React to throw #412 ("Connection closed").

`hydrateOrRender` catches that and degrades, so the failure was silent: content rendered, but the page never hydrated and client-side navigation was dead until a manual reload. The real trigger is a warm module cache plus slow HTML, so a repeat visitor on a poor connection could hit it without clicking anything.

The plugin now waits for a parsed document before reading the payload.

## Verification

A build of this site, served over a **trickled** HTML connection — the document delivered in chunks while assets come from cache, which is the shape that triggers the race. Same server, same build, only the plugin version differs:

| | payload read | hydrated |
|---|---|---|
| 3.1.4 | **8626** of 24932 chars, at `readyState: "loading"` → React #412 | **no** |
| 3.1.5 | **24932** of 24932 chars, after the parse | **yes**, no console errors |

Confirmed the app carries no workaround of its own (`src/client.tsx` is untouched), so this is the plugin fix alone. `tsc` clean; static build produces all 300 pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)