### PR TITLE
chore(deps): vite-plugin-react-server 3.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.1.5",
+        "vite-plugin-react-server": "^3.1.6",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.5.tgz",
-      "integrity": "sha512-wK+CHFx5t4HlyxrlU2PsOZLv8T6OgwtlZ5dGk6odY3zAGtLeTzPc7W0gIU6+cmNFl223k0xlfx2EKpkqy+qjzA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.1.6.tgz",
+      "integrity": "sha512-4Apnlds5779xCv8ifqkllFvFa1Jzk5YA/afQ3DC4t2p3TtjNMt0Ti9EW6t4Ei25M67fpvAt51bhTd8TsfKUM6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.1.5",
+    "vite-plugin-react-server": "^3.1.6",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
3.1.6 stamps the inlined flight payload's length on its `<script>` tag (`data-length`), so the client can tell a whole payload from one the HTML parser is still writing into — instead of inferring it from timing. Anything incomplete falls back to fetching `index.rsc` rather than decoding a truncated flight stream, and the decode never throws.

For this site that clears the last visible symptom: navigating away from a still-loading page used to leave an `atob` `InvalidCharacterError` in the console of the **abandoned** document. Harmless (that document was being discarded, and the page you land on hydrated fine), but noise.

## Verification

A build of this site served over a trickled HTML connection — document delivered in chunks while assets come from cache, the shape that exercises the payload race:

```
✅ mid-load navigation → /10mmc/levels  hydrated=true
   console errors (incl. the abandoned document): NONE
   About, JS ON : ✅ /10mmc/  ✅ /9mmc/
   About, JS OFF: ✅ /10mmc/  ✅ /9mmc/
```

`tsc` clean; static build produces all 300 pages, now emitting `data-length` on the payload tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)