### PR TITLE
fix(deploy): FTP image skip by role — build-emitted hashed assets always upload

### DIFF
--- a/scripts/deploy-ftp-changed.mjs
+++ b/scripts/deploy-ftp-changed.mjs
@@ -1,7 +1,15 @@
 #!/usr/bin/env node
-// Incremental FTP upload: walks dist/static, skips images, and only uploads
-// files whose content differs from the local backup. Bails out unless the
-// backup directory exists, so we always have something to roll back to.
+// Incremental FTP upload: walks dist/static, skips CONTENT images (the big,
+// stable-named theme sets copied from public/), and only uploads files whose
+// content differs from the local backup. Bails out unless the backup directory
+// exists, so we always have something to roll back to.
+//
+// The image skip is by ROLE, not extension: a file is skippable only if its
+// relative path exists in public/ (it was copied, not emitted). Everything the
+// BUILD emitted — content-hashed names that change every build — always
+// uploads regardless of extension. The old extension filter skipped emitted
+// .svg flags (br-<hash>.svg & co) and 404'd them in prod: content images
+// tolerate being skipped because their names are stable; hashed assets do not.
 
 import { Client } from "basic-ftp";
 import { createHash } from "node:crypto";
@@ -44,7 +52,14 @@ const concurrency = (() => {
 })();
 
 const IMAGE_EXT = new Set([".webp", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".avif"]);
-const SKIP_EXT = imagesOnly ? null : (withImages ? new Set() : IMAGE_EXT);
+const publicDir = resolve(process.env.FTP_PUBLIC_DIR ?? "public");
+
+/**
+ * Role test: a dist file whose relative path exists in public/ was COPIED
+ * from there — app content with a stable name. Only these are candidates for
+ * the image skip. Anything else was emitted by the build and must upload.
+ */
+const isPublicContent = (rel) => existsSync(join(publicDir, rel));
 
 if (!existsSync(localDir)) {
   console.error(`[ftp-changed] local dir not found: ${localDir}`);
@@ -63,8 +78,9 @@ console.log(`[ftp-changed] remote:  ${remoteDir}`);
 console.log(`[ftp-changed] local:   ${localDir}`);
 console.log(`[ftp-changed] backup:  ${backupDir}`);
 console.log(
-  `[ftp-changed] images: ${imagesOnly ? "ONLY images" : withImages ? "include" : "skip"} ` +
-    `(${[...IMAGE_EXT].join(", ")})`
+  `[ftp-changed] content images (public/-copied): ${
+    imagesOnly ? "ONLY these" : withImages ? "include" : "skip"
+  } (${[...IMAGE_EXT].join(", ")}); build-emitted files always upload`
 );
 console.log(`[ftp-changed] workers: ${concurrency}`);
 if (dryRun) console.log(`[ftp-changed] DRY RUN — no upload`);
@@ -109,16 +125,18 @@ async function buildPlan() {
 
   for await (const file of walk(localDir)) {
     const ext = extOf(file);
-    const isImage = IMAGE_EXT.has(ext);
-    if (imagesOnly && !isImage) {
+    const rel = relative(localDir, file);
+    // Skippable = image extension AND copied from public/. Build-emitted
+    // files (hashed flags, fonts, chunks) never match and always upload.
+    const contentImage = IMAGE_EXT.has(ext) && isPublicContent(rel);
+    if (imagesOnly && !contentImage) {
       skippedNonImage++;
       continue;
     }
-    if (SKIP_EXT && SKIP_EXT.has(ext)) {
+    if (!imagesOnly && !withImages && contentImage) {
       skippedImage++;
       continue;
     }
-    const rel = relative(localDir, file);
     const backup = join(backupDir, rel);
     const localSize = statSync(file).size;
 


### PR DESCRIPTION
Fixes the P1 from the 2026-07-14 deploy: the extension-based image skip also skipped build-emitted hashed assets, 404ing all 141 flag-icons overflow svgs in prod (`br-1ajqoy82.svg` → 404, Brazil flag broken on level cards). Content images survived two years of this because their names are stable; hashed names change every build.

**Fix**: skip by role. An image is skippable only if its relative path exists in `public/` (copied content). Everything the build emitted uploads regardless of extension — no filename heuristics, the `public/` mirror is the exact role test. `--images-only` now means "only the public/-copied content images", which was always its actual use.

**Dry-run verified** against the live backup mirror: 50 hashed flag svgs in the upload plan, zero theme-content images in it, 2025 content images skipped, plan summary line documents the semantics.

The upload-order concern in the same script stays tracked separately (bead oo2x territory — not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZW2we53tR9EXzdwFgpujs