### PR TITLE
chore: configure the deploy base once — drop the VITE_BASE_URL/VITE_PUBLIC_ORIGIN mirrors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.2.1",
+        "vite-plugin-react-server": "^3.2.3",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.1.tgz",
-      "integrity": "sha512-wlmUNtCXk9elJYXn+vfoIV3PQkqs6KzFlI0goe3XyKKG+1FglpsRnLMJzYgGZW6DPw04tNuL52uFsY4ot+2gQg==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.3.tgz",
+      "integrity": "sha512-UFpTnXnjW1Sq0DB8TqlGVVNCAdrgFGcaNjQY2MytdsTq2eK1RHl+Zqo2u3zHGlkndq2qSXNVEVF6AAoRhZtnLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "NODE_OPTIONS='--conditions react-server' vite build --app",
     "build:app": "vite build --app",
     "build:prod": "npm run env:prod -- vite build --app",
-    "build:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' VITE_PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' VITE_BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true NODE_OPTIONS='--conditions react-server' vite build --app",
+    "build:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true NODE_OPTIONS='--conditions react-server' vite build --app",
     "build:preview": "npm run env:preview -- vite build --app",
     "build:dev": "vite build --app",
     "debug-build": "NODE_ENV=development npm run build",
@@ -47,9 +47,9 @@
     "preview:prod": "npm run startup:prod && npm run build:prod && vite preview",
     "preview:gh": "npm run startup:gh && npm run build:gh && npm run env:gh -- vite preview",
     "oopsie-wsl": "find . -type f -name \"*:Zone.Identifier\" -exec rm {} \\;",
-    "env:prod": "PUBLIC_ORIGIN='https://mmcelebration.com' BASE_URL='/' VITE_PUBLIC_ORIGIN='https://mmcelebration.com' VITE_BASE_URL='/' NODE_ENV=production",
-    "env:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' VITE_PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' VITE_BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true",
-    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/' VITE_PUBLIC_ORIGIN='http://localhost:4173' VITE_BASE_URL='/' NODE_ENV=production",
+    "env:prod": "PUBLIC_ORIGIN='https://mmcelebration.com' BASE_URL='/' NODE_ENV=production",
+    "env:gh": "PUBLIC_ORIGIN='https://nicobrinkkemper.github.io' BASE_URL='/mmc/' NODE_ENV=production GITHUB_ACTIONS=true",
+    "env:preview": "PUBLIC_ORIGIN='http://localhost:4173' BASE_URL='/' NODE_ENV=production",
     "env:dev": "NODE_ENV=development"
   },
   "engines": {
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.2.1",
+    "vite-plugin-react-server": "^3.2.3",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,9 +19,9 @@ const fromMeta = (): { base?: string; origin?: string } => {
 // default too (the old env.server read process.env, which is *undefined*, so ??
 // worked there — import.meta.env bakes "").
 const meta = fromMeta();
-const base = meta.base || process.env["VITE_BASE_URL"] || "/";
+const base = meta.base || process.env["BASE_URL"] || "/";
 const origin =
-  meta.origin || process.env["VITE_PUBLIC_ORIGIN"] || "https://mmcelebration.com";
+  meta.origin || process.env["PUBLIC_ORIGIN"] || "https://mmcelebration.com";
 
 const isAbsolute = (path: string): boolean =>
   /^[a-z][a-z0-9+.-]*:/i.test(path) || path.startsWith("//");

--- a/vite.react.config.tsx
+++ b/vite.react.config.tsx
@@ -46,9 +46,10 @@ const staticPaths = Object.fromEntries(
 // process.env.GITHUB_ACTIONS = "true";
 export const config = {
   moduleBase: "src",
-  publicOrigin: process.env.PUBLIC_ORIGIN || process.env.VITE_PUBLIC_ORIGIN || "",
+  publicOrigin: process.env.PUBLIC_ORIGIN || "",
   moduleBasePath: "/",
-  moduleBaseURL: process.env.BASE_URL || process.env.VITE_BASE_URL || "/",
+  // No moduleBaseURL: vprs ≥3.2.2 takes Vite's `base` (vite.config.ts reads
+  // BASE_URL), so the deploy base is configured once.
   verbose: false,
   routes: {
     dir: "app",


### PR DESCRIPTION
Since vite-plugin-react-server 3.2.3 the plugin takes the deploy base from Vite's own `config.base` and mirrors it into the build env itself, so the workaround from #133 (exporting `VITE_BASE_URL`/`VITE_PUBLIC_ORIGIN` alongside `BASE_URL`/`PUBLIC_ORIGIN` in every env script) is no longer needed.

- npm scripts (`build:gh`, `env:prod`, `env:gh`, `env:preview`): drop the `VITE_`-prefixed exports; the bare vars stay.
- `vite.react.config.tsx`: drop the explicit `moduleBaseURL` (config.base carries it now); `publicOrigin` reads bare `PUBLIC_ORIGIN` only.
- `src/config/env.ts`: the plain-Node fallbacks read the bare vars — the `VITE_` spellings only exist inside vite builds, where the plugin now guarantees them.
- vprs bumped to `^3.2.3`.

Verified: `npm run build:gh` emits `/mmc/`-prefixed bootstrap module URLs on the root page, nested SSG pages, and in the edge bundle's baked `bootstrapModules`; full `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)