### PR TITLE
chore(deps): vite-plugin-react-server 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.2.3",
+        "vite-plugin-react-server": "^3.3.0",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.2.3.tgz",
-      "integrity": "sha512-UFpTnXnjW1Sq0DB8TqlGVVNCAdrgFGcaNjQY2MytdsTq2eK1RHl+Zqo2u3zHGlkndq2qSXNVEVF6AAoRhZtnLg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.3.0.tgz",
+      "integrity": "sha512-A7mjyxKYBmpJYa0RRo/bG+QXkWzhWCYPad8ZMnhcGZ0pFdCrrLWhEGkPoqEnaNvdfHaPa6cvoVUXI6F+lOW0uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.2.3",
+    "vite-plugin-react-server": "^3.3.0",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Quiet default logs (vprs #276) + the metrics overhaul (vprs #277): warm-up first batch so the cold module load is paid once, per-batch overview lines (wall vs sum, parallel factor), one consolidated `index.{rsc,html}` line per route with a modules/route split, and `ssg-render`/`inline-flight`/`edge-bake` summary metrics — all rendered by the `metricWatcher` this repo already wires up in `vite.react.config.tsx`.

Verified during development against this repo's own 300-page `build:gh` (that build was the measurement bench for the whole overhaul); `npm test` green on the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)