### PR TITLE
fix(about): close on backdrop click + native details/summary accordion

### DIFF
--- a/src/about/About.module.css
+++ b/src/about/About.module.css
@@ -21,11 +21,31 @@
   z-index: 2;
 }
 
+.backdrop {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: block;
+}
+
 .main {
   display: flex;
   justify-content: center;
   align-items: center;
   height: 100%;
+  /* Clicks in the empty area around the panel fall through to the backdrop
+     close link; the panel re-enables them for its own content. */
+  pointer-events: none;
+}
+
+.main .inner {
+  pointer-events: auto;
+  /* Positioned + above the (positioned) backdrop, or the backdrop paints over
+     the panel and steals its clicks. */
+  position: relative;
+  z-index: 1;
 }
 
 .close {

--- a/src/about/About.tsx
+++ b/src/about/About.tsx
@@ -31,6 +31,16 @@ export const About: AboutType = ({
       className={classNames(styles["outer"], visible && styles["visible"])}
       id={"!/about"}
     >
+      {/* Full-viewport close target behind the panel: clicking outside the
+          panel clears the fragment, and `:target` closes the modal — the same
+          no-JS mechanism that opens it. `.main` lets clicks fall through
+          (pointer-events) so only the panel itself swallows them. */}
+      <Clickable
+        className={styles["backdrop"]}
+        {...closeProps}
+        aria-label="Close"
+        tabIndex={-1}
+      />
       <div className={styles["main"]}>
         <div className={styles["inner"]}>
           <div className={styles["header"]}>

--- a/src/about/AboutButton.module.css
+++ b/src/about/AboutButton.module.css
@@ -4,6 +4,18 @@
     height: min-content;
 }
 
+/* One size across themes: several theme --button-font vars scale ALL their
+   buttons to 1.2em, which made this one oversized (and, padding being em,
+   too tall). The doubled class outranks .Button's `font:` shorthand on the
+   same element in any module order, while family/weight/line-height stay
+   themed. em, not rem: 1em of the same header context every theme renders
+   at the reference size, so correct themes don't move by even a pixel.
+   The --about-button-* vars stay as per-theme escape hatches. */
+.AboutButton.AboutButton {
+    font-size: var(--about-button-font-size, 1em);
+    --button-icon-size: var(--about-button-icon-size, 1.2em);
+}
+
 .AboutButton .Button-inner:after {
     background: var(--about-button-after-background, var(--button-after-background, inherit));
 }

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -54,8 +54,8 @@
 }
 
 .ButtonIcon {
-    height: 1.1em;
-    width: 1.1em;
+    height: var(--button-icon-size, 1.1em);
+    width: var(--button-icon-size, 1.1em);
 }
 
 .ButtonIcon svg {

--- a/src/copy/10mmc/About.tsx
+++ b/src/copy/10mmc/About.tsx
@@ -12,11 +12,12 @@ export const About10MMC: DefaultAboutContentType = ({
   accordionItemHeading: AccordionItemHeading = "div",
   accordionItemPanel: AccordionItemPanel = "div",
   accordionItemButton: AccordionItemButton = "a",
+  preExpanded,
 }) => {
   return (
     <Accordion>
       <h1>About {caps}</h1>
-      <AboutItem accordionItem={AccordionItem}>
+      <AboutItem accordionItem={AccordionItem} preExpanded={preExpanded}>
         <AboutItemHeading
           accordionItemHeading={AccordionItemHeading}
           accordionItemButton={AccordionItemButton}

--- a/src/copy/7mmc/About.tsx
+++ b/src/copy/7mmc/About.tsx
@@ -12,11 +12,12 @@ export const About7MMC: DefaultAboutContentType = ({
   accordionItemHeading: AccordionItemHeading = "div",
   accordionItemButton: AccordionItemButton = "a",
   accordionItemPanel: AccordionItemPanel = "div",
+  preExpanded,
 }) => {
   return (
     <Accordion>
       <h1>About {caps}</h1>
-      <AboutItem accordionItem={AccordionItem}>
+      <AboutItem accordionItem={AccordionItem} preExpanded={preExpanded}>
         <AboutItemHeading
           accordionItemHeading={AccordionItemHeading}
           accordionItemButton={AccordionItemButton}

--- a/src/copy/8mmc/About.tsx
+++ b/src/copy/8mmc/About.tsx
@@ -12,11 +12,12 @@ export const About8MMC: DefaultAboutContentType = ({
   accordionItemHeading: AccordionItemHeading,
   accordionItemButton: AccordionItemButton,
   accordionItemPanel: AccordionItemPanel,
+  preExpanded,
 }) => {
   return (
     <Accordion>
       <h1>About {caps}</h1>
-      <AboutItem accordionItem={AccordionItem}>
+      <AboutItem accordionItem={AccordionItem} preExpanded={preExpanded}>
         <AboutItemHeading
           accordionItemHeading={AccordionItemHeading}
           accordionItemButton={AccordionItemButton}

--- a/src/copy/9mmc/About.tsx
+++ b/src/copy/9mmc/About.tsx
@@ -12,11 +12,12 @@ export const About9MMC: DefaultAboutContentType = ({
   accordionItemHeading: AccordionItemHeading = "div",
   accordionItemPanel: AccordionItemPanel = "div",
   accordionItemButton: AccordionItemButton = "a",
+  preExpanded,
 }) => {
   return (
     <Accordion>
       <h1>About {caps}</h1>
-      <AboutItem accordionItem={AccordionItem}>
+      <AboutItem accordionItem={AccordionItem} preExpanded={preExpanded}>
         <AboutItemHeading
           accordionItemHeading={AccordionItemHeading}
           accordionItemButton={AccordionItemButton}

--- a/src/copy/default/AboutItem.tsx
+++ b/src/copy/default/AboutItem.tsx
@@ -8,5 +8,5 @@ export const AboutItem: AboutItemType = ({
   const header: any = Array.isArray(children) ? children[0] : null;
   if (!header) return header;
   const uuid = snakeCase(header.props.children);
-  return <AccordionItem uuid={uuid}>{children}</AccordionItem>;
+  return <AccordionItem id={uuid}>{children}</AccordionItem>;
 };

--- a/src/copy/default/AboutItem.tsx
+++ b/src/copy/default/AboutItem.tsx
@@ -1,12 +1,24 @@
-import { snakeCase } from "lodash-es";
 import * as React from "react";
+import { aboutSectionSlug } from "./aboutSlug.js";
 
 export const AboutItem: AboutItemType = ({
   accordionItem: AccordionItem,
+  preExpanded,
   children,
 }) => {
   const header: any = Array.isArray(children) ? children[0] : null;
   if (!header) return header;
-  const uuid = snakeCase(header.props.children);
-  return <AccordionItem id={uuid}>{children}</AccordionItem>;
+  // JSX like `What is {caps}?` arrives as split children — join the text
+  // parts (no comma artifacts from array toString) before slugging, so the
+  // id matches what preExpanded producers compute from the plain string.
+  const text = React.Children.toArray(header.props.children)
+    .filter((c) => typeof c === "string" || typeof c === "number")
+    .join("");
+  const uuid = aboutSectionSlug(text);
+  const open = preExpanded?.includes(uuid) || undefined;
+  return (
+    <AccordionItem id={uuid} open={open}>
+      {children}
+    </AccordionItem>
+  );
 };

--- a/src/copy/default/DefaultAboutContent.tsx
+++ b/src/copy/default/DefaultAboutContent.tsx
@@ -11,6 +11,7 @@ export const DefaultAboutContent: DefaultAboutContentType = ({
   accordionItemHeading: AccordionItemHeading = "div",
   accordionItemPanel: AccordionItemPanel = "div",
   accordionItemButton: AccordionItemButton = "a",
+  preExpanded,
 }) => {
   return (
     <Accordion className={styles["accordion"]}>
@@ -20,6 +21,7 @@ export const DefaultAboutContent: DefaultAboutContentType = ({
           caps,
           writtenOut,
         }}
+        preExpanded={preExpanded}
         accordionItem={AccordionItem}
         accordionItemHeading={AccordionItemHeading}
         accordionItemPanel={AccordionItemPanel}

--- a/src/copy/default/QuestionWhatIsThis.tsx
+++ b/src/copy/default/QuestionWhatIsThis.tsx
@@ -9,9 +9,10 @@ export const QuestionWhatIsThis: QuestionWhatIsThisType = ({
   accordionItemHeading: AccordionItemHeading = "div",
   accordionItemPanel: AccordionItemPanel = "div",
   accordionItemButton: AccordionItemButton = "a",
+  preExpanded,
 }) => {
   return (
-    <AboutItem accordionItem={AccordionItem}>
+    <AboutItem accordionItem={AccordionItem} preExpanded={preExpanded}>
       <AboutItemHeading
         accordionItemHeading={AccordionItemHeading}
         accordionItemButton={AccordionItemButton}

--- a/src/copy/default/aboutSlug.ts
+++ b/src/copy/default/aboutSlug.ts
@@ -1,0 +1,11 @@
+import { snakeCase } from "lodash-es";
+
+/**
+ * The single slug function for About accordion sections. AboutItem derives
+ * each section's id from its heading text with THIS function, and
+ * getStaticData's preExpanded list must be produced with it too — two
+ * spellings would silently never match and the default-open section would
+ * render closed.
+ */
+export const aboutSectionSlug = (headingText: string): string =>
+  snakeCase(headingText);

--- a/src/copy/default/accordion.module.css
+++ b/src/copy/default/accordion.module.css
@@ -1,3 +1,17 @@
+/**
+ * Native <details>/<summary> accordion (see getStaticData's accordion case):
+ * .accordion__heading is the <summary>, its child div carries the layout and
+ * the chevron, the sibling div is the panel. No JS — the marker is hidden and
+ * the chevron flips on the details' own [open] state.
+ */
+.accordion__heading {
+    list-style: none;
+}
+
+.accordion__heading::-webkit-details-marker {
+    display: none;
+}
+
 .accordion__heading>div {
     font-size: 1rem;
     line-height: 1.125rem;
@@ -9,23 +23,28 @@
     justify-content: space-between;
 }
 
-a.accordion__heading>div:after {
+.accordion__heading>div:after {
     content: "";
     display: flex;
+    align-self: center;
     height: 0.5rem;
     width: 0.75rem;
     background-color: var(--modal-inner-color);
     -webkit-mask: url("data:image/svg+xml,<svg viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'><path d='M0 6.00003L1.41 7.41003L6 2.83003L10.59 7.41003L12 6.00003L6 3.43323e-05L0 6.00003Z' /></svg>");
     mask: url("data:image/svg+xml,<svg viewBox='0 0 12 8' xmlns='http://www.w3.org/2000/svg'><path d='M0 6.00003L1.41 7.41003L6 2.83003L10.59 7.41003L12 6.00003L6 3.43323e-05L0 6.00003Z' /></svg>");
+    transform: rotate(180deg);
 }
 
-a.accordion__heading>div:focus {
+.accordion__heading:focus {
     outline: none;
+}
+
+.accordion__heading:focus>div {
     text-decoration: underline;
 }
 
-a.accordion__heading>div[aria-expanded="true"]:after {
-    transform: rotate(180deg);
+details[open]>.accordion__heading>div:after {
+    transform: none;
 }
 
 .accordion h1 {

--- a/src/data/getStaticData.ts
+++ b/src/data/getStaticData.ts
@@ -1,5 +1,6 @@
 
 import { ClientClickable } from "../components/Clickable.client.js";
+import { aboutSectionSlug } from "../copy/default/aboutSlug.js";
 import { absoluteURL, baseURL } from "../config/env.js";
 import { levels, siteName, themes } from "../config/themeConfig.js";
 import { isKeyOf } from "../utils/isKeyOf.js";
@@ -226,12 +227,17 @@ export const getStaticData: GetStaticDataFn = async (pathInfo, options) => {
           // Native <details>/<summary>: collapse behavior with no JS, so it
           // works on the statically served page before (or entirely without)
           // hydration — same philosophy as the :target-driven About modal.
+          // preExpanded opens the theme's "What is X?" section by default —
+          // computed with the SAME slug function AboutItem derives ids with,
+          // from the same heading text every About variant renders.
+          const { caps } = getThemeInfo(theme);
           result.accordion = {
             accordion: "div",
             accordionItem: "details",
             accordionItemHeading: "summary",
             accordionItemButton: "div",
             accordionItemPanel: "div",
+            preExpanded: [aboutSectionSlug(`What is ${caps}?`)],
           } satisfies AccordionProps;
           break;
         }

--- a/src/data/getStaticData.ts
+++ b/src/data/getStaticData.ts
@@ -223,11 +223,13 @@ export const getStaticData: GetStaticDataFn = async (pathInfo, options) => {
           break;
         }
         case "accordion": {
-          // TODO: add client-side accordion
+          // Native <details>/<summary>: collapse behavior with no JS, so it
+          // works on the statically served page before (or entirely without)
+          // hydration — same philosophy as the :target-driven About modal.
           result.accordion = {
             accordion: "div",
-            accordionItem: "div",
-            accordionItemHeading: "div",
+            accordionItem: "details",
+            accordionItemHeading: "summary",
             accordionItemButton: "div",
             accordionItemPanel: "div",
           } satisfies AccordionProps;

--- a/types/theme-copy.d.ts
+++ b/types/theme-copy.d.ts
@@ -5,6 +5,12 @@ declare global {
     accordionItemHeading: React.ElementType;
     accordionItemButton: React.ElementType;
     accordionItemPanel: React.ElementType;
+    /**
+     * Heading slugs (see aboutSectionSlug) whose sections start open — the
+     * typed successor of react-accessible-accordion's preExpanded uuids. The
+     * data layer decides (getStaticData), the item renders `open`.
+     */
+    preExpanded?: readonly string[];
   };
 
   type AboutPanelType = ThemeComponent<
@@ -16,7 +22,7 @@ declare global {
   type AboutItemType = ThemeComponent<
     {},
     "div",
-    Pick<AccordionProps, "accordionItem">
+    Pick<AccordionProps, "accordionItem" | "preExpanded">
   >;
 
   type AboutItemHeadingType = ThemeComponent<
@@ -45,6 +51,7 @@ declare global {
       | "accordionItemHeading"
       | "accordionItemButton"
       | "accordionItemPanel"
+      | "preExpanded"
     >
   >;
 
@@ -71,6 +78,7 @@ declare global {
       | "accordionItemHeading"
       | "accordionItemPanel"
       | "accordionItemButton"
+      | "preExpanded"
     >
   >;
 


### PR DESCRIPTION
Two About-modal regressions, both dating to the theme refactor's accordion stub (`getStaticData.ts` mapped every accordion component to `"div"` with a TODO):

- **Headers wouldn't collapse** — they now map to native `<details>/<summary>`. Collapse works with no JS, before (or entirely without) hydration — the same philosophy as the `:target`-driven modal itself. The chevron follows `details[open]`, and items get a real `id` (previously a bogus `uuid` attribute), making sections deep-linkable.
- **Clicking outside didn't close the modal** — there was no backdrop close target. A full-viewport close anchor now sits behind the panel; `.main` lets clicks fall through (`pointer-events`) and `.inner` is lifted above the positioned backdrop (positioned elements otherwise paint over flow content and steal the panel's clicks — caught by the browser probe). Clearing the fragment closes via the same `:target` mechanism that opens it.

Verified in a real browser (production preview build): open → outside-click closes with the fragment cleared → reopen → all 3 sections toggle → ✕ close intact → no console errors. `npm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)