### PR TITLE
chore(deps): react-server-loader experimental .1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "npm-run-all": "^4.1.5",
         "react": "0.0.0-experimental-172742b4-20260716",
         "react-dom": "0.0.0-experimental-172742b4-20260716",
-        "react-server-loader": "0.0.0-experimental-172742b4-20260716",
+        "react-server-loader": "0.0.0-experimental-172742b4-20260716.1",
         "sharp": "^0.35.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.22.4",
@@ -7508,9 +7508,9 @@
       }
     },
     "node_modules/react-server-loader": {
-      "version": "0.0.0-experimental-172742b4-20260716",
-      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-172742b4-20260716.tgz",
-      "integrity": "sha512-rMYlCpwAMQc7l0M0Nq3dLf+Obufj81D2ggxa9FOgLaBgCfWAS+2uG60b2lpPqKLrzOQj1AcmmDJjkogKpPa7Mw==",
+      "version": "0.0.0-experimental-172742b4-20260716.1",
+      "resolved": "https://registry.npmjs.org/react-server-loader/-/react-server-loader-0.0.0-experimental-172742b4-20260716.1.tgz",
+      "integrity": "sha512-Q+0EOPowK4GLwfDyrRIPOzfgoaKgvNmNlRd3TJKZwOhyo1jdKaBruZWZZ1aN7ZIOlM7l0B69mrHnIcO4H51O+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "npm-run-all": "^4.1.5",
     "react": "0.0.0-experimental-172742b4-20260716",
     "react-dom": "0.0.0-experimental-172742b4-20260716",
-    "react-server-loader": "0.0.0-experimental-172742b4-20260716",
+    "react-server-loader": "0.0.0-experimental-172742b4-20260716.1",
     "sharp": "^0.35.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.22.4",


### PR DESCRIPTION
The rsl revision on the same React nightly ([rsl #29](https://github.com/nicobrinkkemper/react-server-loader/pull/29)'s env-resolved webpack client — inert for this site, which runs the esm transport statically, but it keeps the pin current with the shared loader/transformer code). `react`/`react-dom` stay put by design: same nightly, rsl-only revision. Gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)