### PR TITLE
chore: bump vite-plugin-react-server to v3.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.4.2",
+        "vite-plugin-react-server": "^3.4.3",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.2.tgz",
-      "integrity": "sha512-4ZTj76qxF2bUPLqZdKveNugba2IhbygG3D0UaX3yxhP0Zd2BdSgYj720R1DE3IE/yWeDbMfi3Jy6kE9wNrExUA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.3.tgz",
+      "integrity": "sha512-5dAV0wXqf727+2sRXrDqY1ntIgp/onV+Vk/ukpMGPEoPxrD++fRyUAiDPVJDKsHsb+8PQ7yI5FL0lS+FaHkgpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.3.0",
+        "vite-plugin-react-server": "^3.4.2",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,15 +9170,15 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.3.0.tgz",
-      "integrity": "sha512-A7mjyxKYBmpJYa0RRo/bG+QXkWzhWCYPad8ZMnhcGZ0pFdCrrLWhEGkPoqEnaNvdfHaPa6cvoVUXI6F+lOW0uA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.2.tgz",
+      "integrity": "sha512-4ZTj76qxF2bUPLqZdKveNugba2IhbygG3D0UaX3yxhP0Zd2BdSgYj720R1DE3IE/yWeDbMfi3Jy6kE9wNrExUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
         "picocolors": "^1.1.1",
-        "react-server-loader": "^19.2.17 || 0.0.0-experimental-172742b4-20260716",
+        "react-server-loader": "^19.2.18 || 0.0.0-experimental-172742b4-20260716.1",
         "tsx": "^4.21.0",
         "vitefu": "^1.1.3"
       },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.3.0",
+    "vite-plugin-react-server": "^3.4.2",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.4.2",
+    "vite-plugin-react-server": "^3.4.3",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Bumps vite-plugin-react-server to v3.4.3 (supersedes the 3.4.2 bump on this branch; 3.4.3 adds SSG shell-render error surfacing on top of the 3.4.2 dev fixes).

`npm run build` (including the edge bake) verified green on the registry install. No shell-throwing client components in this repo, so the new fail-loud SSG behavior changes nothing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)