### PR TITLE
chore: bump vite-plugin-react-server to v3.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.4.3",
+        "vite-plugin-react-server": "^3.4.6",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.3.tgz",
-      "integrity": "sha512-5dAV0wXqf727+2sRXrDqY1ntIgp/onV+Vk/ukpMGPEoPxrD++fRyUAiDPVJDKsHsb+8PQ7yI5FL0lS+FaHkgpA==",
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.6.tgz",
+      "integrity": "sha512-4C80UZ+/gppvcaeCazEh35CrU4dZGpNZHTQDbvxPCtsRf4dtm5zZPGxdqi4cvU4a6JL1tXx/9DQStRENGrxT4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.4.3",
+    "vite-plugin-react-server": "^3.4.6",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Bumps vite-plugin-react-server to v3.4.6 (serving-origin URLs — a baked PUBLIC_ORIGIN can no longer split the module graph into two Reacts on an origin mismatch; plus the 3.4.4/3.4.5 dev and test-infra fixes).

`npm run build` (including the edge bake) verified green on the registry install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)