### PR TITLE
chore(deps): vite-plugin-react-server 3.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.4.6",
+        "vite-plugin-react-server": "^3.4.7",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.6.tgz",
-      "integrity": "sha512-4C80UZ+/gppvcaeCazEh35CrU4dZGpNZHTQDbvxPCtsRf4dtm5zZPGxdqi4cvU4a6JL1tXx/9DQStRENGrxT4A==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.7.tgz",
+      "integrity": "sha512-36P3HjgqXZ+9rJKSa2rz9GEO/abGqkv1FGHMEUGaaWM8BK7dQDGKC44t8evmISAJ4vILl24KrZKtQeDo9bZPww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.4.6",
+    "vite-plugin-react-server": "^3.4.7",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Patch release: dev HMR for server-only CSS modules, panic flag across the
worker boundary, hydrateOrRender user-abort wording.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
