### PR TITLE
chore(deps): vite-plugin-react-server 3.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "typescript-plugin-css-modules": "^5.2.0",
         "vite": "^6.4.3",
         "vite-css-modules": "^1.16.0",
-        "vite-plugin-react-server": "^3.4.7",
+        "vite-plugin-react-server": "^3.5.0",
         "vitest": "^3.2.6",
         "webpack-sources": "^3.5.0"
       },
@@ -9170,9 +9170,9 @@
       }
     },
     "node_modules/vite-plugin-react-server": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.4.7.tgz",
-      "integrity": "sha512-36P3HjgqXZ+9rJKSa2rz9GEO/abGqkv1FGHMEUGaaWM8BK7dQDGKC44t8evmISAJ4vILl24KrZKtQeDo9bZPww==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-react-server/-/vite-plugin-react-server-3.5.0.tgz",
+      "integrity": "sha512-8KLnxVTgrdshfhHv9pDIAQVSqj47y5jRJq1qDhxCKKZkDxNg2v8pftbFkHlGDgcKZdgV6ogPPML1q0rLANVYLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "typescript-plugin-css-modules": "^5.2.0",
     "vite": "^6.4.3",
     "vite-css-modules": "^1.16.0",
-    "vite-plugin-react-server": "^3.4.7",
+    "vite-plugin-react-server": "^3.5.0",
     "vitest": "^3.2.6",
     "webpack-sources": "^3.5.0"
   },


### PR DESCRIPTION
Bumps `vite-plugin-react-server` from ^3.4.7 to ^3.5.0, the router parity release: index routes, pathless groups, error/loading boundaries, `head.ts`, and loader `redirect`/`notFound`.

## Verification

- `npm ls vite-plugin-react-server` → 3.5.0 installed
- `npm test` — startup:dev data pipeline + vitest: 2 test files, 2 tests, all passed
- `npm run build` — full static build: 300 pages rendered, flight inlined into all 300, edge producer baked

Only `package.json` and `package-lock.json` change; no generated data files were affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F24bCFmZ82fRkfH5PGgnxy