### PR TITLE
fix(test): stale pathInfo prop; automatic JSX runtime everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build-mmc": "npm run startup && npm run build",
     "tsc": "rm -rf dist && npx tsc --project tsconfig.node.json && find src -name \"*.css\" -exec cp --parents {} dist/ \\;",
     "tsc-watch": "npx tsc --build --watch --incremental --force",
-    "ssg": "run-s build server:crawl",
     "clean-install": "npm install vite-plugin-react-server react@experimental react-dom@experimental react-server-loader@experimental --save-dev",
     "patch": "patch",
     "link-dev": "npm link vite-plugin-react-server",

--- a/test/App.test.tsx
+++ b/test/App.test.tsx
@@ -4,14 +4,7 @@ import { expect, test } from "vitest";
 import { App } from "../src/App.js";
 
 test("renders React App", () => {
-  render(
-    <App
-      pathInfo={{
-        theme: "4ymm",
-      }}
-      children={<div>test</div>}
-    />
-  );
+  render(<App children={<div>test</div>} />);
   const linkElement = screen.getByText(/test/i);
   expect(linkElement).toBeDefined();
 });


### PR DESCRIPTION
Cleanups surfaced while gating the 3.5.0 bump (#160):

- **App test warning**: `test/App.test.tsx` passed `pathInfo` to `App`, but App's props no longer include it (no page passes it either), so React warned about an unknown `pathInfo` prop reaching the DOM via the `...rest` spread. The test now renders App without the stale prop.
- **Dead `ssg` script**: `package.json`'s `ssg` chained `server:crawl`, a script that no longer exists. The `--app` build performs the static render itself, so `ssg` is removed.
- **One JSX transform for all pipelines**: the build warned `"default" is imported from external module "react" but never used`. Root cause: `@vitejs/plugin-react` compiles the build with the automatic JSX runtime, while tsconfig said `"jsx": "react"` (classic), which is what vitest and editors followed — so the same file needed a runtime `React` in tests that the build considered dead. tsconfig now says `"jsx": "react-jsx"`, aligning vitest/tsc/build on the automatic runtime. With that, the sweep: 74 unused `React` imports deleted, 12 type-only usages became `import type * as React`, 5 genuine runtime users keep the namespace import.

Gates: `npx tsc --noEmit` clean, `npm test` (startup + vitest 2/2) with zero unknown-prop warnings, `npm run build` full 300-page static render with zero unused-import warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F24bCFmZ82fRkfH5PGgnxy