### PR TITLE
fix(nav): scroll-to-top resets the .App scroll container, not just window

### DIFF
--- a/src/components/Clickable.client.tsx
+++ b/src/components/Clickable.client.tsx
@@ -31,8 +31,17 @@ export const ClientClickable: React.FC<{
         return;
       }
       e.preventDefault();
-      // Scroll to top on forward navigation (a link click). Doing it here — not
-      // on every popstate — means browser back/forward keeps its scroll offset.
+      // Scroll to top on forward navigation (a link click). Doing it here, not
+      // on every popstate, means browser back/forward keeps its scroll offset.
+      // The window never scrolls: `.App` is the overflow-y container, so reset
+      // every scrolled ancestor of the link (window kept as a fallback).
+      for (
+        let el: HTMLElement | null = e.currentTarget;
+        el;
+        el = el.parentElement
+      ) {
+        if (el.scrollTop > 0) el.scrollTop = 0;
+      }
       if ("scrollTo" in window) window.scrollTo(0, 0);
       // Use pathname, not full href — the router expects a path like "/10mmc/".
       const newTo =


### PR DESCRIPTION
Client-side navigation kept the page's scroll position instead of jumping to top.

`ClientClickable` called `window.scrollTo(0, 0)` on intercepted link clicks, but the window never scrolls in this layout: `.App` is the scroll container (`overflow-y: scroll; max-height: 100vh`). 

The click handler now walks the clicked link's ancestors and resets any element that actually scrolled, keeping the `window.scrollTo` fallback for document-scrolling layouts.

Verified headlessly against the static build (Playwright): before, navigating `/10mmc/levels/` → `/10mmc/levels/1` kept `.App`'s `scrollTop`; after, it resets to 0 on the same client-side navigation. `tsc --noEmit` and vitest (2/2) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F24bCFmZ82fRkfH5PGgnxy